### PR TITLE
Remove the default build target in the Cargo configuration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-[build]
-target = "x86_64-unknown-linux-gnu"
-
 [target.wasm32-unknown-unknown]
 rustflags = [
     # Enabled unstable APIs from web_sys


### PR DESCRIPTION
When I run the command `cargo run -p maplibre-demo` on my Mac (version 11.6.4), the target should be *x86_64-apple-darwin*. 

Because of the default config in `.cargo/config.toml` the target that is used instead is *x86_64-unknown-linux-gnu* and I get the error `error: failed to run custom build command for wayland-sys v0.29.4`.

I have looked at a few major Rust repositories and none seem to use a default cargo target.

I think we should remove the default build target so Rustup will use its active toolchain as shown by `rustup show`.

What do you think?
