### PR TITLE
Write the Microsoft Windows build documentation

### DIFF
--- a/docs/src/development-guide/building.md
+++ b/docs/src/development-guide/building.md
@@ -83,6 +83,7 @@ Finally you can run the command:
 
 ```bash
 cargo build -p maplibre-demo --target x86_64-pc-windows-msvc
+```
 
 > The target may vary depending on the CPU architecture you are targetting for your build. On ARM64 you would
 > use the target aarch64-pc-windows-msvc instead. If you are building for your current operating system, 

--- a/docs/src/development-guide/building.md
+++ b/docs/src/development-guide/building.md
@@ -81,7 +81,7 @@ During the installation select the C++ tools. Restart your machine after the ins
 
 Finally you can run the command:
 
-bash
+```bash
 cargo build -p maplibre-demo --target x86_64-pc-windows-msvc
 
 > The target may vary depending on the CPU architecture you are targetting for your build. On ARM64 you would

--- a/docs/src/development-guide/building.md
+++ b/docs/src/development-guide/building.md
@@ -69,6 +69,25 @@ corresponds to your system. Otherwise, XCode will tell you that the app is incom
 In order to change that, go into *Build settings -> Deployment -> MacOS deployment target* and select your OSX version.
 Finally, you can click on the run button to start the application.
 
+## Microsoft Windows
+
+You can build executables for Microsoft Windows with the `cargo build` command. You will need to install 
+[rustup](https://rustup.rs/) and [CMake](https://cmake.org/download/). CMake is required by some libraries
+to build c/c++ code. 
+
+You also need to install the 
+[Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16). 
+During the installation select the C++ tools. Restart your machine after the installation is complete.
+
+Finally you can run the command:
+
+bash
+cargo build -p maplibre-demo --target x86_64-pc-windows-msvc
+
+> The target may vary depending on the CPU architecture you are targetting for your build. On ARM64 you would
+> use the target aarch64-pc-windows-msvc instead. If you are building for your current operating system, 
+> you shouldn't have to specify the target, it should be automatically configured by rustup.
+
 ## Web (WebGL, WebGPU)
 
 If you have a browser which already supports a recent version of the WebGPU specification then you can start a


### PR DESCRIPTION
Maplibre-rs doesn't have a documentation for Microsoft Windows yet. There are some requirements that need to be installed such as Visual Studio c++ build tools. It is important to test and document it.

We'll probably want to make a Github Action for Windows releases in the future.

## ✔️ PR Todo

- [x] Write the documentation.
- [ ] Visual studio build tools for c++ probably already installs CMake so we can remove this step.
- [ ] Figure out what is the issue with sqlite3.lib when building the app.
- [ ] Test out on a fresh Windows 10 install (maybe Windows 11?).
- [ ] Check for errors and inconsistencies in the documentation.