### PR TITLE
Add Windows as a target OS in Cargo dependencies

### DIFF
--- a/maplibre/Cargo.toml
+++ b/maplibre/Cargo.toml
@@ -16,7 +16,7 @@ no-thread-safe-futures = []
 
 
 
-[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android"))'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android", target_os = "windows"))'.dependencies]
 tokio = { version = "1.17", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 env_logger = "0.9"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "gzip"] }


### PR DESCRIPTION
Windows was missing in the list of target OS in the Cargo dependencies. This caused builds to fail on Windows because dependencies were missing.

## 💻 Examples

\-

## 🚨 Test instructions

Using `cargo run -p maplibre-demo` on a Windows OS now works.

## ✔️ PR Todo

- [ ] Add Windows to the target_os list in the cargo dependencies
