### PR TITLE
Fix window resizing in headed mode

### DIFF
--- a/maplibre/src/render/resource/surface.rs
+++ b/maplibre/src/render/resource/surface.rs
@@ -225,19 +225,14 @@ impl Surface {
 
     pub fn resize(&mut self, width: u32, height: u32) {
         self.size = WindowSize::new(width, height).expect("Invalid size for resizing the surface.");
-        match &mut self.head {
-            Head::Headed(window) => {
-                window.surface_config.height = height;
-                window.surface_config.width = width;
-            }
-            Head::Headless(_) => {}
-        }
     }
 
     pub fn reconfigure(&mut self, device: &wgpu::Device) {
         match &mut self.head {
             Head::Headed(window) => {
                 if window.has_changed(&(self.size.width(), self.size.height())) {
+                    window.surface_config.height = self.size.height();
+                    window.surface_config.width = self.size.width();
                     window.configure(device);
                 }
             }


### PR DESCRIPTION
In headed mode, when `resize` is called in `surface.rs`, we update the `surface_config` width and height. Because of that, the`reconfigure` method of the `surface.rs` does not detect any change in the width and height and doesn't call `window.configure`, which is required to apply the `surface_config` to the actual surface.

I propose that we only change `surface.rs` width and height in `resize`, and the actual `surface_config` and `configure` method are updated in the `reconfigure` method called in the render Resource stage.

Related issue #132 

## 💻 Examples

This is a bug fix to allow resizing windows.

## 🚨 Test instructions

Try to resize the window and it should work.

## ✔️ PR Todo

\-
