### PR TITLE
Reduce znear so the map is not cut when we tilt the camera

### DIFF
--- a/maplibre-winit/src/input/pan_handler.rs
+++ b/maplibre-winit/src/input/pan_handler.rs
@@ -30,10 +30,16 @@ impl UpdateState for PanHandler {
                 let inverted_view_proj = view_proj.invert();
 
                 let delta = if let (Some(start), Some(current)) = (
-                    reference_camera
-                        .window_to_world_at_ground(&start_window_position, &inverted_view_proj),
-                    reference_camera
-                        .window_to_world_at_ground(&window_position, &inverted_view_proj),
+                    reference_camera.window_to_world_at_ground(
+                        &start_window_position,
+                        &inverted_view_proj,
+                        false,
+                    ),
+                    reference_camera.window_to_world_at_ground(
+                        &window_position,
+                        &inverted_view_proj,
+                        false,
+                    ),
                 ) {
                     start - current
                 } else {

--- a/maplibre-winit/src/input/query_handler.rs
+++ b/maplibre-winit/src/input/query_handler.rs
@@ -65,10 +65,11 @@ impl UpdateState for QueryHandler {
                 let _z = state.visible_level(); // FIXME: can be wrong, if tiles of different z are visible
                 let _zoom = state.zoom();
 
-                if let Some(_coordinates) = state
-                    .camera
-                    .window_to_world_at_ground(&window_position, &inverted_view_proj)
-                {
+                if let Some(_coordinates) = state.camera.window_to_world_at_ground(
+                    &window_position,
+                    &inverted_view_proj,
+                    false,
+                ) {
                     /*state
                     .scheduler()
                     .schedule_method()

--- a/maplibre-winit/src/input/zoom_handler.rs
+++ b/maplibre-winit/src/input/zoom_handler.rs
@@ -26,10 +26,11 @@ impl UpdateState for ZoomHandler {
                 let view_proj = state.view_projection();
                 let inverted_view_proj = view_proj.invert();
 
-                if let Some(cursor_position) = state
-                    .camera
-                    .window_to_world_at_ground(&window_position, &inverted_view_proj)
-                {
+                if let Some(cursor_position) = state.camera.window_to_world_at_ground(
+                    &window_position,
+                    &inverted_view_proj,
+                    false,
+                ) {
                     let scale = current_zoom.scale_delta(&next_zoom);
 
                     let delta = Vector3::new(

--- a/maplibre/src/context.rs
+++ b/maplibre/src/context.rs
@@ -25,8 +25,13 @@ impl ViewState {
             window_size.width(),
             window_size.height(),
             cgmath::Deg(110.0),
-            1.0,
-            2000.0,
+            // in tile.vertex.wgsl we are setting each layer's final `z` in ndc space to `z_index`.
+            // This means that regardless of the `znear` value all layers will be rendered as part
+            // of the near plane.
+            // These values have been selected experimentally:
+            // https://www.sjbaker.org/steve/omniv/love_your_z_buffer.html
+            1024.0,
+            2048.0,
         );
 
         Self {

--- a/maplibre/src/context.rs
+++ b/maplibre/src/context.rs
@@ -25,7 +25,7 @@ impl ViewState {
             window_size.width(),
             window_size.height(),
             cgmath::Deg(110.0),
-            100.0,
+            1.0,
             2000.0,
         );
 

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -240,6 +240,7 @@ impl Camera {
         &self,
         window: &Vector2<f64>,
         inverted_view_proj: &InvertedViewProjection,
+        bound: bool,
     ) -> Option<Vector3<f64>> {
         let near_world =
             self.window_to_world(&Vector3::new(window.x, window.y, 0.0), inverted_view_proj);
@@ -250,7 +251,7 @@ impl Camera {
         // for z = 0 in world coordinates
         // Idea comes from: https://dondi.lmu.build/share/cg/unproject-explained.pdf
         let u = -near_world.z / (far_world.z - near_world.z);
-        if (0.0..=1.0).contains(&u) {
+        if !bound || (0.0..=1.0).contains(&u) {
             Some(near_world + u * (far_world - near_world))
         } else {
             None
@@ -277,7 +278,7 @@ impl Camera {
             Vector2::new(self.width, self.height),
             Vector2::new(0.0, self.height),
         ]
-        .map(|point| self.window_to_world_at_ground(&point, inverted_view_proj));
+        .map(|point| self.window_to_world_at_ground(&point, inverted_view_proj, false));
 
         let (min, max) = bounds_from_points(
             screen_bounding_box

--- a/maplibre/src/render/resource/buffer_pool.rs
+++ b/maplibre/src/render/resource/buffer_pool.rs
@@ -1,6 +1,7 @@
 //! A ring-buffer like pool of [buffers](wgpu::Buffer).
 
 use crate::coords::{Quadkey, WorldTileCoords};
+use crate::render::resource::Queue;
 use crate::style::layer::StyleLayer;
 use crate::tessellation::OverAlignedVertexBuffer;
 use bytemuck::Pod;
@@ -15,16 +16,6 @@ pub const INDICES_SIZE: wgpu::BufferAddress = 1_000_000;
 
 pub const FEATURE_METADATA_SIZE: wgpu::BufferAddress = 1024 * 1000;
 pub const LAYER_METADATA_SIZE: wgpu::BufferAddress = 1024;
-
-pub trait Queue<B> {
-    fn write_buffer(&self, buffer: &B, offset: wgpu::BufferAddress, data: &[u8]);
-}
-
-impl Queue<wgpu::Buffer> for wgpu::Queue {
-    fn write_buffer(&self, buffer: &wgpu::Buffer, offset: wgpu::BufferAddress, data: &[u8]) {
-        self.write_buffer(buffer, offset, data)
-    }
-}
 
 /// This is inspired by the memory pool in Vulkan documented
 /// [here](https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/custom_memory_pools.html).

--- a/maplibre/src/render/resource/mod.rs
+++ b/maplibre/src/render/resource/mod.rs
@@ -16,3 +16,13 @@ pub use shader::*;
 pub use surface::*;
 pub use texture::*;
 pub use tracked_render_pass::*;
+
+pub trait Queue<B> {
+    fn write_buffer(&self, buffer: &B, offset: wgpu::BufferAddress, data: &[u8]);
+}
+
+impl Queue<wgpu::Buffer> for wgpu::Queue {
+    fn write_buffer(&self, buffer: &wgpu::Buffer, offset: wgpu::BufferAddress, data: &[u8]) {
+        self.write_buffer(buffer, offset, data)
+    }
+}


### PR DESCRIPTION
When we tilt the camera using the R and F keys, the map clips. If we decrease the near clip plane to 1 it no longer does that. 

Fixing this highlights another problem which should be resolved separately in another pr/issue. When tilting the screen we get `thread 'main' panicked at 'Error in Queue::write_buffer: copy of 0..4216 would end up overrunning the bounds of the Destination buffer of size 2176'`. We should: limit the data we write to the buffer; display a lower zoom level for far away tiles when we tilt the screen.

## 💻 Examples

Here is a screen shot with the map clipping due to a big znear value.

![Screenshot 2022-06-15 at 12 53 45](https://user-images.githubusercontent.com/3996615/173810713-c1ab1eba-d678-4db2-ba84-15136c261b68.png)

## 🚨 Test instructions

Run the maplibre demo and press R or F.

## ✔️ PR Todo

\-
