### PR TITLE
Improve Mapbox Style support

### DIFF
--- a/maplibre/src/context.rs
+++ b/maplibre/src/context.rs
@@ -1,4 +1,4 @@
-use crate::coords::{WorldCoords, Zoom, ZoomLevel, TILE_SIZE};
+use crate::coords::{LatLon, WorldCoords, Zoom, ZoomLevel, TILE_SIZE};
 use crate::io::tile_repository::TileRepository;
 use crate::render::camera::{Camera, Perspective, ViewProjection};
 use crate::util::ChangeObserver;
@@ -12,19 +12,12 @@ pub struct ViewState {
 }
 
 impl ViewState {
-    pub fn new(window_size: &WindowSize, style: &Style) -> Self {
-        let zoom = style.zoom.map_or_else(
-            || ChangeObserver::default(),
-            |zoom| ChangeObserver::new(Zoom::new(zoom)),
-        );
-        let (lat, lon) = style
-            .center
-            .map_or((0.0, 0.0), |center| (center[0], center[1]));
-        let position = WorldCoords::from_lat_lon(lat, lon, zoom.0);
+    pub fn new(window_size: &WindowSize, zoom: Zoom, center: LatLon, pitch: f64) -> Self {
+        let position = WorldCoords::from_lat_lon(center, zoom);
         let camera = Camera::new(
             (position.x, position.y, 150.0),
             cgmath::Deg(-90.0),
-            cgmath::Deg(style.pitch.unwrap_or(0.0)),
+            cgmath::Deg(pitch),
             window_size.width(),
             window_size.height(),
         );
@@ -38,7 +31,7 @@ impl ViewState {
         );
 
         Self {
-            zoom,
+            zoom: ChangeObserver::new(zoom),
             camera: ChangeObserver::new(camera),
             perspective,
         }

--- a/maplibre/src/context.rs
+++ b/maplibre/src/context.rs
@@ -1,4 +1,4 @@
-use crate::coords::{Zoom, ZoomLevel, TILE_SIZE, WorldCoords};
+use crate::coords::{WorldCoords, Zoom, ZoomLevel, TILE_SIZE};
 use crate::io::tile_repository::TileRepository;
 use crate::render::camera::{Camera, Perspective, ViewProjection};
 use crate::util::ChangeObserver;
@@ -13,8 +13,13 @@ pub struct ViewState {
 
 impl ViewState {
     pub fn new(window_size: &WindowSize, style: &Style) -> Self {
-        let zoom = style.zoom.map_or_else(|| ChangeObserver::default(), |zoom| ChangeObserver::new(Zoom::new(zoom)));
-        let (lat, lon) = style.center.map_or((0.0, 0.0), |center| (center[0], center[1]));
+        let zoom = style.zoom.map_or_else(
+            || ChangeObserver::default(),
+            |zoom| ChangeObserver::new(Zoom::new(zoom)),
+        );
+        let (lat, lon) = style
+            .center
+            .map_or((0.0, 0.0), |center| (center[0], center[1]));
         let position = WorldCoords::from_lat_lon(lat, lon, zoom.0);
         let camera = Camera::new(
             (position.x, position.y, 150.0),

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -1,5 +1,6 @@
 //! Provides utilities related to coordinates.
 
+use std::f64::consts::PI;
 use crate::style::source::TileAddressingScheme;
 use crate::util::math::{div_floor, Aabb2};
 use crate::util::SignificantlyDifferent;
@@ -115,7 +116,7 @@ impl Into<u8> for ZoomLevel {
 /// `Zoom` is an exponential scale that defines the zoom of the camera on the map.
 /// We can derive the `ZoomLevel` from `Zoom` by using the `[crate::coords::ZOOM_BOUNDS]`.
 #[derive(Copy, Clone, Debug)]
-pub struct Zoom(f64);
+pub struct Zoom(pub(crate) f64);
 
 impl Zoom {
     pub fn new(zoom: f64) -> Self {
@@ -460,6 +461,21 @@ fn tiles_with_z(z: u8) -> f64 {
 }
 
 impl WorldCoords {
+    pub fn from_lat_lon(latitude: f64, longitude: f64, zoom: f64) -> WorldCoords {
+        let tile_size = TILE_SIZE * 2.0_f64.powf(zoom);
+        // Get x value
+        let x = (longitude + 180.0) * (tile_size / 360.0);
+
+        // Convert from degrees to radians
+        let lat_rad = (latitude * PI) / 180.0;
+
+        // get y value
+        let merc_n = f64::ln(f64::tan((PI / 4.0) + (lat_rad / 2.0)));
+        let y = (tile_size / 2.0) - (tile_size * merc_n / (2.0 * PI));
+
+        WorldCoords{x, y}
+    }
+
     pub fn at_ground(x: f64, y: f64) -> Self {
         Self { x, y }
     }

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -1,11 +1,11 @@
 //! Provides utilities related to coordinates.
 
-use std::f64::consts::PI;
 use crate::style::source::TileAddressingScheme;
 use crate::util::math::{div_floor, Aabb2};
 use crate::util::SignificantlyDifferent;
 use cgmath::num_traits::Pow;
 use cgmath::{AbsDiffEq, Matrix4, Point3, Vector3};
+use std::f64::consts::PI;
 use std::fmt;
 
 pub const EXTENT_UINT: u32 = 4096;
@@ -473,7 +473,7 @@ impl WorldCoords {
         let merc_n = f64::ln(f64::tan((PI / 4.0) + (lat_rad / 2.0)));
         let y = (tile_size / 2.0) - (tile_size * merc_n / (2.0 * PI));
 
-        WorldCoords{x, y}
+        WorldCoords { x, y }
     }
 
     pub fn at_ground(x: f64, y: f64) -> Self {

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -113,10 +113,25 @@ impl Into<u8> for ZoomLevel {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+pub struct LatLon(f64, f64);
+
+impl LatLon {
+    pub fn new(latitude: f64, longitude: f64) -> Self {
+        LatLon(latitude, longitude)
+    }
+}
+
+impl Default for LatLon {
+    fn default() -> Self {
+        LatLon(0.0, 0.0)
+    }
+}
+
 /// `Zoom` is an exponential scale that defines the zoom of the camera on the map.
 /// We can derive the `ZoomLevel` from `Zoom` by using the `[crate::coords::ZOOM_BOUNDS]`.
 #[derive(Copy, Clone, Debug)]
-pub struct Zoom(pub(crate) f64);
+pub struct Zoom(f64);
 
 impl Zoom {
     pub fn new(zoom: f64) -> Self {
@@ -461,13 +476,13 @@ fn tiles_with_z(z: u8) -> f64 {
 }
 
 impl WorldCoords {
-    pub fn from_lat_lon(latitude: f64, longitude: f64, zoom: f64) -> WorldCoords {
-        let tile_size = TILE_SIZE * 2.0_f64.powf(zoom);
+    pub fn from_lat_lon(lat_lon: LatLon, zoom: Zoom) -> WorldCoords {
+        let tile_size = TILE_SIZE * 2.0_f64.powf(zoom.0);
         // Get x value
-        let x = (longitude + 180.0) * (tile_size / 360.0);
+        let x = (lat_lon.1 + 180.0) * (tile_size / 360.0);
 
         // Convert from degrees to radians
-        let lat_rad = (latitude * PI) / 180.0;
+        let lat_rad = (lat_lon.0 * PI) / 180.0;
 
         // get y value
         let merc_n = f64::ln(f64::tan((PI / 4.0) + (lat_rad / 2.0)));

--- a/maplibre/src/headless.rs
+++ b/maplibre/src/headless.rs
@@ -1,5 +1,5 @@
 use crate::context::{MapContext, ViewState};
-use crate::coords::{ViewRegion, Zoom};
+use crate::coords::{LatLon, ViewRegion, Zoom};
 use crate::error::Error;
 use crate::io::tile_repository::TileRepository;
 use crate::render::camera::ViewProjection;
@@ -97,7 +97,12 @@ where
         http_client: HC,
         style: Style,
     ) -> Self {
-        let view_state = ViewState::new(&window_size, &style);
+        let view_state = ViewState::new(
+            &window_size,
+            style.zoom.map_or(Zoom::default(), |zoom| Zoom::new(zoom)),
+            style.center.map_or(LatLon::default(), |center| LatLon::new(center[0], center[1])),
+            style.pitch.unwrap_or(0.0)
+        );
         let tile_repository = TileRepository::new();
         let mut schedule = Schedule::default();
 

--- a/maplibre/src/headless.rs
+++ b/maplibre/src/headless.rs
@@ -97,7 +97,7 @@ where
         http_client: HC,
         style: Style,
     ) -> Self {
-        let view_state = ViewState::new(&window_size);
+        let view_state = ViewState::new(&window_size, &style);
         let tile_repository = TileRepository::new();
         let mut schedule = Schedule::default();
 

--- a/maplibre/src/headless.rs
+++ b/maplibre/src/headless.rs
@@ -99,9 +99,12 @@ where
     ) -> Self {
         let view_state = ViewState::new(
             &window_size,
-            style.zoom.map_or(Zoom::default(), |zoom| Zoom::new(zoom)),
-            style.center.map_or(LatLon::default(), |center| LatLon::new(center[0], center[1])),
-            style.pitch.unwrap_or(0.0)
+            style.zoom.map(|zoom| Zoom::new(zoom)).unwrap_or_default(),
+            style
+                .center
+                .map(|center| LatLon::new(center[0], center[1]))
+                .unwrap_or_default(),
+            style.pitch.unwrap_or_default(),
         );
         let tile_repository = TileRepository::new();
         let mut schedule = Schedule::default();

--- a/maplibre/src/map_schedule.rs
+++ b/maplibre/src/map_schedule.rs
@@ -5,6 +5,7 @@ use crate::io::scheduler::Scheduler;
 use crate::io::source_client::{HttpClient, HttpSourceClient};
 use crate::io::tile_repository::TileRepository;
 
+use crate::coords::{LatLon, Zoom};
 use crate::render::{create_default_render_graph, register_default_render_stages};
 use crate::schedule::{Schedule, Stage};
 use crate::stages::register_stages;
@@ -51,7 +52,12 @@ where
         wgpu_settings: WgpuSettings,
         renderer_settings: RendererSettings,
     ) -> Self {
-        let view_state = ViewState::new(&window_size, &style);
+        let view_state = ViewState::new(
+            &window_size,
+            style.zoom.map_or(Zoom::default(), |zoom| Zoom::new(zoom)),
+            style.center.map_or(LatLon::default(), |center| LatLon::new(center[0], center[1])),
+            style.pitch.unwrap_or(0.0)
+        );
         let tile_repository = TileRepository::new();
         let mut schedule = Schedule::default();
 

--- a/maplibre/src/map_schedule.rs
+++ b/maplibre/src/map_schedule.rs
@@ -54,9 +54,12 @@ where
     ) -> Self {
         let view_state = ViewState::new(
             &window_size,
-            style.zoom.map_or(Zoom::default(), |zoom| Zoom::new(zoom)),
-            style.center.map_or(LatLon::default(), |center| LatLon::new(center[0], center[1])),
-            style.pitch.unwrap_or(0.0)
+            style.zoom.map(|zoom| Zoom::new(zoom)).unwrap_or_default(),
+            style
+                .center
+                .map(|center| LatLon::new(center[0], center[1]))
+                .unwrap_or_default(),
+            style.pitch.unwrap_or_default(),
         );
         let tile_repository = TileRepository::new();
         let mut schedule = Schedule::default();

--- a/maplibre/src/map_schedule.rs
+++ b/maplibre/src/map_schedule.rs
@@ -51,7 +51,7 @@ where
         wgpu_settings: WgpuSettings,
         renderer_settings: RendererSettings,
     ) -> Self {
-        let view_state = ViewState::new(&window_size);
+        let view_state = ViewState::new(&window_size, &style);
         let tile_repository = TileRepository::new();
         let mut schedule = Schedule::default();
 

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -67,7 +67,7 @@ impl ModelViewProjection {
 
 #[derive(Debug, Clone)]
 pub struct Camera {
-    pub position: Point3<f64>,
+    pub position: Point3<f64>, // The z axis never changes, the zoom is used instead
     pub yaw: cgmath::Rad<f64>,
     pub pitch: cgmath::Rad<f64>,
 

--- a/maplibre/src/style/style.rs
+++ b/maplibre/src/style/style.rs
@@ -27,9 +27,7 @@ impl Default for Style {
             name: "Default Style".to_string(),
             metadata: Default::default(),
             sources: Default::default(),
-            center: Some([
-                46.5197, 6.6323
-            ]),
+            center: Some([46.5197, 6.6323]),
             pitch: Some(0.0),
             zoom: Some(13.0),
             layers: vec![

--- a/maplibre/src/style/style.rs
+++ b/maplibre/src/style/style.rs
@@ -15,6 +15,9 @@ pub struct Style {
     pub metadata: HashMap<String, String>,
     pub sources: HashMap<String, Source>,
     pub layers: Vec<StyleLayer>,
+    pub center: Option<[f64; 2]>,
+    pub zoom: Option<f64>,
+    pub pitch: Option<f64>,
 }
 
 impl Default for Style {
@@ -24,6 +27,11 @@ impl Default for Style {
             name: "Default Style".to_string(),
             metadata: Default::default(),
             sources: Default::default(),
+            center: Some([
+                46.5197, 6.6323
+            ]),
+            pitch: Some(0.0),
+            zoom: Some(13.0),
             layers: vec![
                 StyleLayer {
                     index: 0,


### PR DESCRIPTION
Currently we only support a small subset of the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/root/). In the future, we would like to improve this support and to dynamically load styles from files.

## 💻 Examples

\-

## 🚨 Test instructions

\-

## ✔️ PR Todo

- [x] Add root level elements support such as center (in latitude/longitude), zoom and pitch
