### PR TITLE
Limit the tiles in view

### DIFF
--- a/maplibre/src/context.rs
+++ b/maplibre/src/context.rs
@@ -1,4 +1,4 @@
-use crate::coords::{Zoom, ZoomLevel, TILE_SIZE};
+use crate::coords::{ViewRegion, Zoom, ZoomLevel, TILE_SIZE};
 use crate::io::tile_repository::TileRepository;
 use crate::render::camera::{Camera, Perspective, ViewProjection};
 use crate::util::ChangeObserver;
@@ -34,6 +34,14 @@ impl ViewState {
             camera: ChangeObserver::new(camera),
             perspective,
         }
+    }
+
+    pub fn create_view_region(&self) -> Option<ViewRegion> {
+        self.camera
+            .view_region_bounding_box(&self.view_projection().invert())
+            .map(|bounding_box| {
+                ViewRegion::new(bounding_box, 0, 32, *self.zoom, self.visible_level())
+            })
     }
 
     pub fn view_projection(&self) -> ViewProjection {

--- a/maplibre/src/context.rs
+++ b/maplibre/src/context.rs
@@ -1,4 +1,4 @@
-use crate::coords::{LatLon, WorldCoords, ViewRegion, Zoom, ZoomLevel, TILE_SIZE};
+use crate::coords::{LatLon, ViewRegion, WorldCoords, Zoom, ZoomLevel, TILE_SIZE};
 use crate::io::tile_repository::TileRepository;
 use crate::render::camera::{Camera, Perspective, ViewProjection};
 use crate::util::ChangeObserver;

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -678,6 +678,7 @@ mod tests {
         for tile_coords in ViewRegion::new(
             Aabb2::new(Point2::new(0.0, 0.0), Point2::new(2000.0, 2000.0)),
             1,
+            32,
             Zoom::default(),
             ZoomLevel::default(),
         )

--- a/maplibre/src/render/stages/extract_stage.rs
+++ b/maplibre/src/render/stages/extract_stage.rs
@@ -33,16 +33,7 @@ impl Stage for ExtractStage {
         if let (Initialized(tile_view_pattern), Initialized(buffer_pool)) =
             (tile_view_pattern, &buffer_pool)
         {
-            let visible_level = view_state.visible_level();
-
-            let view_proj = view_state.view_projection();
-
-            let view_region = view_state
-                .camera
-                .view_region_bounding_box(&view_proj.invert())
-                .map(|bounding_box| {
-                    ViewRegion::new(bounding_box, 0, *view_state.zoom, visible_level)
-                });
+            let view_region = view_state.create_view_region();
 
             if let Some(view_region) = &view_region {
                 let zoom = view_state.zoom();

--- a/maplibre/src/render/stages/resource_stage.rs
+++ b/maplibre/src/render/stages/resource_stage.rs
@@ -8,13 +8,11 @@ use crate::render::resource::{Globals, RenderPipeline};
 use crate::render::shaders;
 use crate::render::shaders::{Shader, ShaderTileMetadata};
 use crate::render::tile_pipeline::TilePipeline;
-use crate::render::tile_view_pattern::TileViewPattern;
+use crate::render::tile_view_pattern::{TileViewPattern, DEFAULT_TILE_VIEW_SIZE};
 use crate::schedule::Stage;
 use crate::Renderer;
 
 use std::mem::size_of;
-
-pub const TILE_VIEW_SIZE: wgpu::BufferAddress = 32;
 
 #[derive(Default)]
 pub struct ResourceStage;
@@ -83,7 +81,8 @@ impl Stage for ResourceStage {
         state.tile_view_pattern.initialize(|| {
             let tile_view_buffer_desc = wgpu::BufferDescriptor {
                 label: Some("tile view buffer"),
-                size: size_of::<ShaderTileMetadata>() as wgpu::BufferAddress * TILE_VIEW_SIZE,
+                size: size_of::<ShaderTileMetadata>() as wgpu::BufferAddress
+                    * DEFAULT_TILE_VIEW_SIZE,
                 usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
                 mapped_at_creation: false,
             };

--- a/maplibre/src/render/stages/upload_stage.rs
+++ b/maplibre/src/render/stages/upload_stage.rs
@@ -30,8 +30,6 @@ impl Stage for UploadStage {
             ..
         }: &mut MapContext,
     ) {
-        let visible_level = view_state.visible_level();
-
         let view_proj = view_state.view_projection();
 
         if let Initialized(globals_bind_group) = &state.globals_bind_group {
@@ -52,10 +50,7 @@ impl Stage for UploadStage {
             );
         }
 
-        let view_region = view_state
-            .camera
-            .view_region_bounding_box(&view_proj.invert())
-            .map(|bounding_box| ViewRegion::new(bounding_box, 0, *view_state.zoom, visible_level));
+        let view_region = view_state.create_view_region();
 
         if let Some(view_region) = &view_region {
             self.upload_tile_geometry(state, queue, tile_repository, style, view_region);

--- a/maplibre/src/stages/request_stage.rs
+++ b/maplibre/src/stages/request_stage.rs
@@ -55,14 +55,7 @@ where
             ..
         }: &mut MapContext,
     ) {
-        let visible_level = view_state.visible_level();
-
-        let view_proj = view_state.view_projection();
-
-        let view_region = view_state
-            .camera
-            .view_region_bounding_box(&view_proj.invert())
-            .map(|bounding_box| ViewRegion::new(bounding_box, 0, *view_state.zoom, visible_level));
+        let view_region = view_state.create_view_region();
 
         if view_state.camera.did_change(0.05) || view_state.zoom.did_change(0.05) || self.try_failed
         {


### PR DESCRIPTION
Previously we allowed infinitely many tiles in view. This caused buffer overflows.

This works around this issue:
```
thread 'main' panicked at 'Error in Queue::write_buffer: copy of 0..4216 would end up overrunning the bounds of the Destination buffer of size 2176'
```