### PR TITLE
Fix building guide link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ cargo run -p maplibre-demo
 ```
 
 More information about building for different platforms can be
-found [here](https://maplibre.org/maplibre-rs/docs/book/development-guide/building.html).
+found [here](https://maplibre.org/maplibre-rs/docs/book/development-guide/how-to-run.html).
 
 ## Rust Setup
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Build and run it on a desktop
 cargo run -p maplibre-demo
 ```
 
-More information about building for different platforms can be
+More information about running the demos on different platforms can be
 found [here](https://maplibre.org/maplibre-rs/docs/book/development-guide/how-to-run.html).
 
 ## Rust Setup


### PR DESCRIPTION
Link to information on how to build for different platforms went to a 404. Changing to the current url.