### PR TITLE
Update deps with cargo upgrade

### DIFF
--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 [dependencies]
 maplibre = { path = "../maplibre" }
 maplibre-winit = { path = "../maplibre-winit", version = "0.0.1"  }
-env_logger = "0.9"
-log = "0.4.16"
+env_logger = "0.9.0"
+log = "0.4.17"
 ndk-glue = "0.5.0" # version is required by winit
 jni = "0.19.0"
 

--- a/apple/Cargo.toml
+++ b/apple/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 maplibre = { path = "../maplibre" }
 maplibre-winit = { path = "../maplibre-winit", version = "0.0.1"  }
 
-env_logger = "0.9"
+env_logger = "0.9.0"
 
 [lib]
 name = "maplibre_apple"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 maplibre = { path = "../maplibre", features = ["headless", "embed-static-tiles"] }
 
 [dev-dependencies]
-criterion = { version = "0.3", features = ["async_tokio"] }
-tokio = "1.18.2"
+criterion = { version = "0.3.6", features = ["async_tokio"] }
+tokio = "1.19.2"
 
 [[bench]]
 name = "render"

--- a/maplibre-build-tools/Cargo.toml
+++ b/maplibre-build-tools/Cargo.toml
@@ -13,8 +13,8 @@ sqlite = ["rusqlite"]
 
 [dependencies]
 naga = { git = "https://github.com/gfx-rs/naga", branch = "master", features = ["wgsl-in"] }
-walkdir = "2.3"
-log = "0.4"
-rusqlite = {version= "0.26", optional=true}
-serde_json = "1.0"
-flate2 = "1.0"
+walkdir = "2.3.2"
+log = "0.4.17"
+rusqlite = { version = "0.27.0", optional = true }
+serde_json = "1.0.82"
+flate2 = "1.0.24"

--- a/maplibre-demo/Cargo.toml
+++ b/maplibre-demo/Cargo.toml
@@ -13,11 +13,11 @@ web-webgl = ["maplibre/web-webgl"]
 trace = ["maplibre/trace", "tracing-subscriber", "tracing-tracy", "tracy-client"]
 
 [dependencies]
-env_logger = "0.9"
+env_logger = "0.9.0"
 maplibre = { path = "../maplibre", version = "0.0.2", features = ["headless"]  }
 maplibre-winit = { path = "../maplibre-winit", version = "0.0.1"  }
 
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", optional = true }
-tracing-tracy = { version = "0.8", optional = true }
-tracy-client = { version = "0.12.7", optional = true }
+tracing = "0.1.35"
+tracing-subscriber = { version = "0.3.14", optional = true }
+tracing-tracy = { version = "0.10.0", optional = true }
+tracy-client = { version = "0.14.0", optional = true }

--- a/maplibre-winit/Cargo.toml
+++ b/maplibre-winit/Cargo.toml
@@ -4,22 +4,22 @@ version = "0.0.1"
 edition = "2021"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android", target_os = "windows"))'.dependencies]
-tokio = { version = "1.17", features = ["rt"] }
+tokio = { version = "1.19.2", features = ["rt"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-winit = { version = "0.26", default-features = false }
+winit = { version = "0.26.1", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-winit = { version = "0.26", default-features = false, features = ["x11", "wayland"] }
+winit = { version = "0.26.1", default-features = false, features = ["x11", "wayland"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3", features = ["Window"] }
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3.58", features = ["Window"] }
+wasm-bindgen = "0.2.81"
+wasm-bindgen-futures = "0.4.31"
 
 [dependencies]
 maplibre = { path = "../maplibre", version = "0.0.2" }
-winit = { version = "0.26", default-features = false }
+winit = { version = "0.26.1", default-features = false }
 cgmath = "0.18.0"
-instant = { version = "0.1", features = ["wasm-bindgen"] } # FIXME: Untrusted dependency
-log = "0.4"
+instant = { version = "0.1.12", features = ["wasm-bindgen"] } # FIXME: Untrusted dependency
+log = "0.4.17"

--- a/maplibre/Cargo.toml
+++ b/maplibre/Cargo.toml
@@ -18,69 +18,69 @@ headless = ["png"]
 
 
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android", target_os = "windows"))'.dependencies]
-tokio = { version = "1.17", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
-env_logger = "0.9"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "gzip"] }
-reqwest-middleware-cache = "0.1" # FIXME: Untrusted dependency
-reqwest-middleware = { version = "0.1" } # FIXME: Untrusted dependency
-tracing-tracy = { version = "0.8", optional = true }
-tracy-client = { version = "0.12.7", optional = true }
+tokio = { version = "1.19.2", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+env_logger = "0.9.0"
+reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "gzip"] }
+reqwest-middleware-cache = "0.1.1" # FIXME: Untrusted dependency
+reqwest-middleware = "0.1.6" # FIXME: Untrusted dependency
+tracing-tracy = { version = "0.10.0", optional = true }
+tracy-client = { version = "0.14.0", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Use rusttls on android because cross compiling is difficult
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "gzip"] }
+reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "gzip"] }
 
 [dependencies]
-async-trait = "0.1"
-instant = { version = "0.1", features = ["wasm-bindgen"] } # FIXME: Untrusted dependency
+async-trait = "0.1.56"
+instant = { version = "0.1.12", features = ["wasm-bindgen"] } # FIXME: Untrusted dependency
 
 # Tracing
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", optional = true }
+tracing = "0.1.35"
+tracing-subscriber = { version = "0.3.14", optional = true }
 
 # Maths
-cgmath = "0.18"
+cgmath = "0.18.0"
 
 # Geo
-geo = { version = "0.19" }
-geo-types = { version = "0.7", features = ["use-rstar_0_9"] }
-rstar = { version = "0.9" }
-prost = "0.10.1"
-geozero = { version = "0.9.4", default-features = false, features = ["with-mvt", "with-geo"]}
-tile-grid = "0.3"
+geo = "0.22.1"
+geo-types = { version = "0.7.6", features = ["use-rstar_0_9"] }
+rstar = "0.9.3"
+prost = "0.10.4"
+geozero = { version = "0.9.4", default-features = false, features = ["with-mvt", "with-geo"] }
+tile-grid = "0.3.0"
 
 # Rendering
-wgpu = "0.13.0"
-lyon = { version = "0.17", features = [] }
-raw-window-handle = "0.4"
+wgpu = "0.13.1"
+lyon = { version = "0.17.10", features = [] }
+raw-window-handle = "0.4.3"
 
 # cached = "0.32"
 
 # Logging
-log = "0.4"
+log = "0.4.17"
 
 # Utils
-bytemuck = "1.2.0"
-bytemuck_derive = "1.0"
+bytemuck = "1.10.0"
+bytemuck_derive = "1.1.0"
 
 # Static tiles inclusion
 include_dir = "0.7.2"
 
 # JSON
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.138", features = ["derive"] }
+serde_json = "1.0.82"
 
 # Colors
-csscolorparser = { version = "0.5", features = ["serde", "cint"]}
-cint = "0.2"
+csscolorparser = { version = "0.6.0", features = ["serde", "cint"] }
+cint = "0.3.1"
 
 # Required by bevy renderer
-thiserror = "1"
-downcast-rs = "1.2"
-smallvec = "1.8"
+thiserror = "1.0.31"
+downcast-rs = "1.2.0"
+smallvec = "1.9.0"
 
 # Headless
-png = { version = "0.17", optional = true }
+png = { version = "0.17.5", optional = true }
 
 [build-dependencies]
 maplibre-build-tools = { path = "../maplibre-build-tools", version = "0.1.0" }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -18,23 +18,23 @@ wasm-opt = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-trait = "0.1"
+async-trait = "0.1.56"
 maplibre = { path = "../maplibre", features = ["no-thread-safe-futures"] }
 maplibre-winit = { path = "../maplibre-winit", version = "0.0.1"  }
-log = "0.4"
+log = "0.4.17"
 
-console_error_panic_hook = "0.1"
-web-sys = { version = "0.3", features = [
+console_error_panic_hook = "0.1.7"
+web-sys = { version = "0.3.58", features = [
     "Window",
     "Worker", "WorkerGlobalScope", "DedicatedWorkerGlobalScope", "MessageEvent",
     "Request", "RequestInit", "RequestMode", "Response", "Headers",
     "ErrorEvent"
 ] }
-js-sys = "0.3"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
-console_log = { version = "0.2", features = ["color"] }
-tracing-wasm = { version = "0.2", optional = true } # FIXME: Low quality dependency
+js-sys = "0.3.58"
+wasm-bindgen = "0.2.81"
+wasm-bindgen-futures = "0.4.31"
+console_log = { version = "0.2.0", features = ["color"] }
+tracing-wasm = { version = "0.2.1", optional = true } # FIXME: Low quality dependency
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "0.3.31"


### PR DESCRIPTION
I noticed that quite many dependencies were behind their latest versions, and ran the cargo upgrade to get the project up to speed. All packages except of the ndk-glue for android are on their latest release.