### PR TITLE
Fixes #138 - upgraded tracy-client to 0.14.* and tracing-tracy to 0.10.*

### DIFF
--- a/docs/src/development-guide/debugging.md
+++ b/docs/src/development-guide/debugging.md
@@ -11,4 +11,24 @@
 
 ## Frame Profiling
 
-* tracing crate
+maplibre-rs is set up to use the Tracy profiler (https://github.com/wolfpld/tracy). It's mainly designed for C++ but has some Rust support.
+
+The connection to Rust uses a project that connects to the tracing crate (https://github.com/nagisa/rust_tracy_client). This uses a set of three crates (tracing-tracy, tracy-client, tracy-client-sys).
+
+Unfortunately, the Tracy project does not use semantic versioning, whereas tracing-tracy, tracy-client, tracy-client sys do.
+
+The current version of the Rust client is at v0.8.1 of Tracy. See the correlating versions in the table below (original at https://github.com/nagisa/rust_tracy_client#version-support-table):
+
+| Tracy | tracy-client-sys | tracy-client | tracing-tracy |
+| ----- | ---------------- | ------------ | ------------- |
+| 0.7.1 | 0.9.0            | 0.8.0        | 0.2.0         |
+| 0.7.3 | 0.10.0           | 0.9.0        | 0.3.0         |
+| 0.7.4 | 0.11.0           | 0.10.0       | 0.4.0         |
+| 0.7.5 | 0.12.0           | 0.11.0       | 0.5.0         |
+| 0.7.6 | 0.13.0, 0.14.0   | 0.12.*       | 0.6.*         |
+| v0.7.7 | 0.15.0          | 0.12.*       | 0.6.*         |
+| v0.7.8 | 0.16.0          | 0.12.*       | 0.6.*         |
+| v0.7.8 | 0.16.0          | 0.12.*       | 0.7.*         |
+| v0.7.8 | 0.16.0          | 0.12.*       | 0.8.*         |
+| v0.8.1 | 0.17.*          | 0.13.*       | 0.9.*         |
+| v0.8.1 | 0.17.*          | 0.14.*       | 0.10.*        |

--- a/maplibre-demo/Cargo.toml
+++ b/maplibre-demo/Cargo.toml
@@ -19,5 +19,5 @@ maplibre-winit = { path = "../maplibre-winit", version = "0.0.1"  }
 
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.14", optional = true }
-tracing-tracy = { version = "0.8", optional = true }
-tracy-client = { version = "0.12.7", optional = true }
+tracing-tracy = { version = "0.10", optional = true }
+tracy-client = { version = "0.14", optional = true }

--- a/maplibre/Cargo.toml
+++ b/maplibre/Cargo.toml
@@ -23,8 +23,8 @@ env_logger = "0.9.0"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "gzip"] }
 reqwest-middleware-cache = "0.1.1" # FIXME: Untrusted dependency
 reqwest-middleware = "0.1.6" # FIXME: Untrusted dependency
-tracing-tracy = { version = "0.8", optional = true }
-tracy-client = { version = "0.12.7", optional = true }
+tracing-tracy = { version = "0.10", optional = true }
+tracy-client = { version = "0.14", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Use rusttls on android because cross compiling is difficult

--- a/maplibre/src/platform/noweb/mod.rs
+++ b/maplibre/src/platform/noweb/mod.rs
@@ -12,7 +12,7 @@ pub fn run_multithreaded<F: Future>(future: F) -> F::Output {
         .enable_time()
         .on_thread_start(|| {
             #[cfg(feature = "trace")]
-            tracy_client::set_thread_name("tokio-runtime-worker");
+            tracy_client::set_thread_name!("tokio-runtime-worker");
         })
         .build()
         .unwrap()


### PR DESCRIPTION
Updated tracy dependencies to 0.8.1, with tracy-client to 0.14.* and tracing-tracy to 0.10.*

## 🚨 Test instructions

Re-run maplibre-demo without any additional errors.

- #138
