### PR TITLE
Fixes #27 - switched to macos-12 runner which is GA since 2022-06-13

### DIFF
--- a/.github/workflows/demo-macos.yml
+++ b/.github/workflows/demo-macos.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   demo-macos:
     name: Build
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
       - uses: extractions/setup-just@v1

--- a/.github/workflows/library-apple.yml
+++ b/.github/workflows/library-apple.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   library-apple:
     name: Build
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
       - uses: extractions/setup-just@v1


### PR DESCRIPTION
Updated to match the current version of the macOS runner now being macos-12:
https://github.blog/changelog/2022-06-13-github-actions-macos-12-for-github-hosted-runners-is-now-generally-available/

## 🚨 Test instructions

Action needs to be re-run through GitHub to check success.

- #27 
