### PR TITLE
Implement 3d extrusion of buildings

### DIFF
--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -378,7 +378,7 @@ impl WorldTileCoords {
         // Divide by EXTENT to normalize tile
         // Scale tiles where zoom level = self.z to 512x512
         let normalize_and_scale =
-            Matrix4::from_nonuniform_scale(tile_scale / EXTENT, tile_scale / EXTENT, 1.0);
+            Matrix4::from_nonuniform_scale(tile_scale / EXTENT, tile_scale / EXTENT, tile_scale / EXTENT);
         translate * normalize_and_scale
     }
 

--- a/maplibre/src/headless.rs
+++ b/maplibre/src/headless.rs
@@ -193,6 +193,7 @@ impl<E: Environment> HeadlessMapSchedule<E> {
         let request = TileRequest {
             coords: WorldTileCoords::default(),
             layers: source_layers,
+            style: Style::default()
         };
 
         pipeline.process((request, data), &mut pipeline_context);

--- a/maplibre/src/io/mod.rs
+++ b/maplibre/src/io/mod.rs
@@ -18,12 +18,14 @@ pub mod tile_repository;
 pub mod transferables;
 
 pub use geozero::mvt::tile::Layer as RawLayer;
+use crate::style::Style;
 
 /// A request for a tile at the given coordinates and in the given layers.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TileRequest {
     pub coords: WorldTileCoords,
     pub layers: HashSet<String>,
+    pub style: Style
 }
 
 impl fmt::Debug for TileRequest {

--- a/maplibre/src/io/tile_pipelines.rs
+++ b/maplibre/src/io/tile_pipelines.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use cgmath::InnerSpace;
 
 use geozero::GeozeroDatasource;
 use prost::Message;
@@ -11,6 +12,7 @@ use crate::{
     },
     tessellation::{zero_tessellator::ZeroTessellator, IndexDataType},
 };
+use crate::render::ShaderVertex;
 
 #[derive(Default)]
 pub struct ParseTile;
@@ -89,6 +91,74 @@ impl Processable for TessellateLayer {
                     e
                 );
             } else {
+
+                let layer_style = tile_request.style.layers
+                    .iter()
+                    .find(|layer_style| layer.name == *layer_style.source_layer
+                        .as_ref()
+                        .unwrap_or(&"".to_string()))
+                    .unwrap();
+
+                // Extrude all the buildings on the z axis if osm_3d_extrusion is enabled on the layer
+                if layer_style.extrusion {
+
+                    // We create a list of all the outer/contour edges. Meaning that these
+                    // edges are not inside the 2d mesh, and a "wall" should be instantiated for them.
+                    // In order to do that, we create a `HashSet` of every edge that appears only
+                    // once in the entire layer.
+                    let mut contour_edges : HashSet<(u32,u32)> = HashSet::with_capacity(tessellator.buffer.indices.len());
+                    for i in 0..tessellator.buffer.indices.len(){
+                        let a = tessellator.buffer.indices[i];
+                        let b = tessellator.buffer.indices[if (i + 1) % 3 == 0 { i - 2 } else { i + 1 } ];
+
+                        // If the contour edge already exist, it is an inner edge and not a contour edge so we remove it
+                        if contour_edges.contains(&(b,a)) {
+                            contour_edges.remove(&(b,a));
+                        } else{
+                            contour_edges.insert((a,b));
+                        }
+                    }
+
+                    // For each "wall" of the buildings, we create 2 triangles in the clockwise
+                    // direction so that their normals are facing outward.
+                    let mut extruded_vertices = vec!();
+                    let mut side_faces_indices = vec!();
+                    for mut edge in contour_edges{
+                        let edge_vector = [
+                            tessellator.buffer.vertices[edge.1 as usize].position[0] - tessellator.buffer.vertices[edge.0 as usize].position[0],
+                            tessellator.buffer.vertices[edge.1 as usize].position[1] - tessellator.buffer.vertices[edge.0 as usize].position[1],
+                            0.0
+                        ];
+                        let normal_vector = cgmath::Vector3::from([-edge_vector[1], edge_vector[0], 0.0]).normalize().into();
+                        let a_position = tessellator.buffer.vertices[edge.0 as usize].position;
+                        let b_position = tessellator.buffer.vertices[edge.1 as usize].position;
+                        extruded_vertices.push(ShaderVertex::new([a_position[0], a_position[1], 0.0], normal_vector));
+                        let a = (extruded_vertices.len() + tessellator.buffer.vertices.len() - 1) as u32;
+                        extruded_vertices.push(ShaderVertex::new([b_position[0], b_position[1], 0.0], normal_vector));
+                        let b = (extruded_vertices.len() + tessellator.buffer.vertices.len() - 1) as u32;
+                        extruded_vertices.push(ShaderVertex::new([a_position[0], a_position[1], 40.0], normal_vector));
+                        let a_extruded = (extruded_vertices.len() + tessellator.buffer.vertices.len() - 1) as u32;
+                        extruded_vertices.push(ShaderVertex::new([b_position[0], b_position[1], 40.0], normal_vector));
+                        let b_extruded = (extruded_vertices.len() + tessellator.buffer.vertices.len() - 1) as u32;
+                        side_faces_indices.push(a);
+                        side_faces_indices.push(b_extruded);
+                        side_faces_indices.push(a_extruded);
+                        side_faces_indices.push(b);
+                        side_faces_indices.push(b_extruded);
+                        side_faces_indices.push(a);
+                    }
+
+                    // We move the vertices to the top, because the bottom will not be visible anyway.
+                    for i in 0..tessellator.buffer.vertices.len(){
+                        tessellator.buffer.vertices[i] = ShaderVertex::new([tessellator.buffer.vertices[i].position[0], tessellator.buffer.vertices[i].position[1], 40.0], tessellator.buffer.vertices[i].normal);
+                    }
+
+                    // We insert the new walls to the buffer.
+                    tessellator.buffer.vertices.extend(extruded_vertices.iter());
+                    tessellator.buffer.indices.extend(side_faces_indices.iter());
+                }
+
+                // We send the tessellated layer to the pipeline.
                 context.processor_mut().layer_tesselation_finished(
                     coords,
                     tessellator.buffer.into(),

--- a/maplibre/src/render/shaders/mod.rs
+++ b/maplibre/src/render/shaders/mod.rs
@@ -99,13 +99,13 @@ impl Shader for TileShader {
                         // position
                         wgpu::VertexAttribute {
                             offset: 0,
-                            format: wgpu::VertexFormat::Float32x2,
+                            format: wgpu::VertexFormat::Float32x3,
                             shader_location: 0,
                         },
                         // normal
                         wgpu::VertexAttribute {
-                            offset: wgpu::VertexFormat::Float32x2.size(),
-                            format: wgpu::VertexFormat::Float32x2,
+                            offset: wgpu::VertexFormat::Float32x3.size(),
+                            format: wgpu::VertexFormat::Float32x3,
                             shader_location: 1,
                         },
                     ],
@@ -226,14 +226,41 @@ impl Default for ShaderCamera {
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
+pub struct ShaderLight {
+    direction: Vec4f32,
+    color: Vec4f32,
+}
+
+impl ShaderLight {
+    pub fn new(direction: Vec4f32, color: Vec4f32) -> Self {
+        Self {
+            direction,
+            color,
+        }
+    }
+}
+
+impl Default for ShaderLight {
+    fn default() -> Self {
+        Self {
+            direction: [-0.3, -0.4, 1.0, 0.0], // Sun orientation
+            color: [1.0, 1.0, 1.0, 1.0], // Sun color and intensity
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
 pub struct ShaderGlobals {
     camera: ShaderCamera,
+    light: ShaderLight,
 }
 
 impl ShaderGlobals {
-    pub fn new(camera_uniform: ShaderCamera) -> Self {
+    pub fn new(camera_uniform: ShaderCamera, light_uniform: ShaderLight) -> Self {
         Self {
             camera: camera_uniform,
+            light: light_uniform,
         }
     }
 }
@@ -241,19 +268,19 @@ impl ShaderGlobals {
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct ShaderVertex {
-    pub position: Vec2f32,
-    pub normal: Vec2f32,
+    pub position: Vec3f32,
+    pub normal: Vec3f32,
 }
 
 impl ShaderVertex {
-    pub fn new(position: Vec2f32, normal: Vec2f32) -> Self {
+    pub fn new(position: Vec3f32, normal: Vec3f32) -> Self {
         Self { position, normal }
     }
 }
 
 impl Default for ShaderVertex {
     fn default() -> Self {
-        ShaderVertex::new([0.0, 0.0], [0.0, 0.0])
+        ShaderVertex::new([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
     }
 }
 

--- a/maplibre/src/render/shaders/tile.fragment.wgsl
+++ b/maplibre/src/render/shaders/tile.fragment.wgsl
@@ -1,8 +1,35 @@
+struct ShaderCamera {
+    view_proj: mat4x4<f32>,
+    view_position: vec4<f32>,
+};
+
+struct ShaderLight {
+    direction: vec4<f32>,
+    color: vec4<f32>,
+}
+
+struct ShaderGlobals {
+    camera: ShaderCamera,
+    light: ShaderLight,
+};
+
+@group(0) @binding(0) var<uniform> globals: ShaderGlobals;
+
 struct Output {
     @location(0) out_color: vec4<f32>,
 };
 
 @fragment
-fn main(@location(0) v_color: vec4<f32>) -> Output {
-    return Output(v_color);
+fn main(@builtin(position) position: vec4<f32>, @location(0) v_color: vec4<f32>, @location(1) normal: vec3<f32>) -> Output {
+
+    // We don't need (or want) much ambient light, so 0.1 is fine
+    let ambient_strength = 0.1;
+    let ambient_color = globals.light.color.xyz * ambient_strength;
+
+    let diffuse_strength = max(dot(normal, globals.light.direction.xyz), 0.0);
+    let diffuse_color = globals.light.color.xyz * diffuse_strength;
+
+    let result = (ambient_color + diffuse_color) * v_color.xyz;
+
+    return Output(vec4<f32>(result, v_color.a));
 }

--- a/maplibre/src/render/shaders/tile.vertex.wgsl
+++ b/maplibre/src/render/shaders/tile.vertex.wgsl
@@ -3,21 +3,28 @@ struct ShaderCamera {
     view_position: vec4<f32>,
 };
 
+struct ShaderLight {
+    direction: vec4<f32>,
+    color: vec4<f32>,
+}
+
 struct ShaderGlobals {
     camera: ShaderCamera,
+    light: ShaderLight,
 };
 
 @group(0) @binding(0) var<uniform> globals: ShaderGlobals;
 
 struct VertexOutput {
-    @location(0)  v_color: vec4<f32>,
     @builtin(position) position: vec4<f32>,
+    @location(0)  v_color: vec4<f32>,
+    @location(1) normal: vec3<f32>,
 };
 
 @vertex
 fn main(
-    @location(0) position: vec2<f32>,
-    @location(1) normal: vec2<f32>,
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
     @location(4) translate1: vec4<f32>,
     @location(5) translate2: vec4<f32>,
     @location(6) translate3: vec4<f32>,
@@ -27,7 +34,6 @@ fn main(
     @location(10) z_index: f32,
     @builtin(instance_index) instance_idx: u32 // instance_index is used when we have multiple instances of the same "object"
 ) -> VertexOutput {
-    let z = 0.0;
     let width = 3.0 * zoom_factor;
 
     // The following code moves all "invisible" vertices to (0, 0, 0)
@@ -35,9 +41,9 @@ fn main(
     //   return VertexOutput(color, vec4<f32>(0.0, 0.0, 0.0, 1.0));
     //}
 
-    var position = mat4x4<f32>(translate1, translate2, translate3, translate4) * vec4<f32>(position + normal * width, z, 1.0);
+    var position = mat4x4<f32>(translate1, translate2, translate3, translate4) * vec4<f32>(position + normal * width, 1.0);
     // FIXME: how to fix z-fighting?
     position.z = z_index;
 
-    return VertexOutput(color, position);
+    return VertexOutput(position, color, normal);
 }

--- a/maplibre/src/render/stages/upload_stage.rs
+++ b/maplibre/src/render/stages/upload_stage.rs
@@ -9,7 +9,7 @@ use crate::{
     render::{
         camera::ViewProjection,
         eventually::Eventually::Initialized,
-        shaders::{ShaderCamera, ShaderFeatureStyle, ShaderGlobals, ShaderLayerMetadata, Vec4f32},
+        shaders::{ShaderCamera, ShaderLight, ShaderFeatureStyle, ShaderGlobals, ShaderLayerMetadata, Vec4f32},
     },
     schedule::Stage,
     RenderState, Renderer, Style,
@@ -46,7 +46,7 @@ impl Stage for UploadStage {
                         .cast::<f32>()
                         .unwrap() // TODO: Remove unwrap
                         .into(),
-                ))]),
+                ), ShaderLight::default())]),
             );
         }
 

--- a/maplibre/src/render/tile_pipeline.rs
+++ b/maplibre/src/render/tile_pipeline.rs
@@ -77,7 +77,7 @@ impl RenderPipeline for TilePipeline {
             layout: if self.bind_globals {
                 Some(vec![vec![wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,

--- a/maplibre/src/stages/request_stage.rs
+++ b/maplibre/src/stages/request_stage.rs
@@ -132,7 +132,7 @@ impl<E: Environment> RequestStage<E> {
         for coords in view_region.iter() {
             if coords.build_quad_key().is_some() {
                 // TODO: Make tesselation depend on style?
-                self.request_tile(tile_repository, &coords, &source_layers)
+                self.request_tile(tile_repository, &coords, &source_layers, style)
                     .unwrap(); // TODO: Remove unwrap
             }
         }
@@ -143,6 +143,7 @@ impl<E: Environment> RequestStage<E> {
         tile_repository: &mut TileRepository,
         coords: &WorldTileCoords,
         layers: &HashSet<String>,
+        style: &Style
     ) -> Result<(), Error> {
         /*        if !tile_repository.is_layers_missing(coords, layers) {
             return Ok(false);
@@ -156,6 +157,7 @@ impl<E: Environment> RequestStage<E> {
                 Input::TileRequest(TileRequest {
                     coords: *coords,
                     layers: layers.clone(),
+                    style: style.clone()
                 }),
                 schedule::<
                     E,

--- a/maplibre/src/style/layer.rs
+++ b/maplibre/src/style/layer.rs
@@ -78,6 +78,7 @@ pub struct StyleLayer {
     pub source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_layer: Option<String>,
+    pub extrusion: bool,
 }
 
 impl Default for StyleLayer {
@@ -92,6 +93,7 @@ impl Default for StyleLayer {
             paint: None,
             source: None,
             source_layer: Some("does not exist".to_string()),
+            extrusion: false,
         }
     }
 }

--- a/maplibre/src/style/style.rs
+++ b/maplibre/src/style/style.rs
@@ -46,6 +46,7 @@ impl Default for Style {
                     })),
                     source: None,
                     source_layer: Some("park".to_string()),
+                    extrusion: false,
                 },
                 StyleLayer {
                     index: 1,
@@ -59,6 +60,7 @@ impl Default for Style {
                     })),
                     source: None,
                     source_layer: Some("landuse".to_string()),
+                    extrusion: false,
                 },
                 StyleLayer {
                     index: 2,
@@ -72,6 +74,7 @@ impl Default for Style {
                     })),
                     source: None,
                     source_layer: Some("landcover".to_string()),
+                    extrusion: false,
                 },
                 StyleLayer {
                     index: 3,
@@ -85,6 +88,7 @@ impl Default for Style {
                     })),
                     source: None,
                     source_layer: Some("transportation".to_string()),
+                    extrusion: false,
                 },
                 StyleLayer {
                     index: 4,
@@ -98,6 +102,7 @@ impl Default for Style {
                     })),
                     source: None,
                     source_layer: Some("building".to_string()),
+                    extrusion: true,
                 },
                 StyleLayer {
                     index: 4,
@@ -111,6 +116,7 @@ impl Default for Style {
                     })),
                     source: None,
                     source_layer: Some("water".to_string()),
+                    extrusion: false,
                 },
                 StyleLayer {
                     index: 6,
@@ -124,6 +130,7 @@ impl Default for Style {
                     })),
                     source: None,
                     source_layer: Some("waterway".to_string()),
+                    extrusion: false,
                 },
                 StyleLayer {
                     index: 7,
@@ -137,6 +144,7 @@ impl Default for Style {
                     })),
                     source: None,
                     source_layer: Some("boundary".to_string()),
+                    extrusion: false,
                 },
             ],
         }

--- a/maplibre/src/tessellation/mod.rs
+++ b/maplibre/src/tessellation/mod.rs
@@ -29,15 +29,15 @@ pub struct VertexConstructor {}
 
 impl FillVertexConstructor<ShaderVertex> for VertexConstructor {
     fn new_vertex(&mut self, vertex: FillVertex) -> ShaderVertex {
-        ShaderVertex::new(vertex.position().to_array(), [0.0, 0.0])
+        ShaderVertex::new([vertex.position().x, vertex.position().y, 0.0], [0.0, 0.0, 1.0])
     }
 }
 
 impl StrokeVertexConstructor<ShaderVertex> for VertexConstructor {
     fn new_vertex(&mut self, vertex: StrokeVertex) -> ShaderVertex {
         ShaderVertex::new(
-            vertex.position_on_path().to_array(),
-            vertex.normal().to_array(),
+            [vertex.position().x, vertex.position().y, 0.0],
+            [0.0, 0.0, 1.0],
         )
     }
 }


### PR DESCRIPTION
This is a simple implementation for showcasing 3d possibilities in Maplibre-rs. 

We simply take the elements in the buildings layer and extrude them with a fixed height.

In the future, it would be very interesting to add details to the buildings that are extruded and extrude based on the height metadata available in OSM.

Extrusion can be enabled/disabled in the `Style` configuration.

Finally I probably should split the function in `tile_pipelines.rs` into smaller functions to make it easier to understand.