### PR TITLE
Postponed: Self-hosted CI runner for macOS

### DIFF
--- a/.github/workflows/library-apple.yml
+++ b/.github/workflows/library-apple.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   library-apple:
     name: Build
-    runs-on: maplibre-ci-runner-m1-mac-2
+    runs-on: macos-12-arm
     steps:
       - uses: actions/checkout@v3
       - name: Setup

--- a/.github/workflows/library-apple.yml
+++ b/.github/workflows/library-apple.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   library-apple:
     name: Build
-    runs-on: macos-12
+    runs-on: maplibre-ci-runner-m1-mac-2
     steps:
       - uses: actions/checkout@v3
       - name: Setup


### PR DESCRIPTION
We need to clarify security requirements: https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners#self-hosted-runner-security