### PR TITLE
Clippy fixes

### DIFF
--- a/maplibre-build-tools/src/wgsl.rs
+++ b/maplibre-build-tools/src/wgsl.rs
@@ -80,7 +80,7 @@ pub fn validate_project_wgsl() {
                                         {
                                             format!(":{}:{} {}", line_number, line_position, error)
                                         } else {
-                                            format!("{}", error)
+                                            error
                                         },
                                     WgslError::IoErr(error) => format!(": {:?}", error),
                                 }

--- a/maplibre/src/headless/map.rs
+++ b/maplibre/src/headless/map.rs
@@ -117,7 +117,7 @@ impl HeadlessMap {
             &mut pipeline_context,
         );
 
-        let mut processor = pipeline_context
+        let processor = pipeline_context
             .take_processor::<HeadlessPipelineProcessor>()
             .expect("Unable to get processor");
 

--- a/maplibre/src/io/geometry_index.rs
+++ b/maplibre/src/io/geometry_index.rs
@@ -62,6 +62,12 @@ impl GeometryIndex {
     }
 }
 
+impl Default for GeometryIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Index of tiles which can be of two types: spatial or linear.
 /// Spatial tiles are stored in a multi-dimentional tree which represents their position in the tile.
 /// Linear tiles are simply stored in a vector.
@@ -195,6 +201,12 @@ impl IndexProcessor {
 
     pub fn get_geometries(self) -> Vec<IndexedGeometry<f64>> {
         self.geometries
+    }
+}
+
+impl Default for IndexProcessor {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/maplibre/src/io/tile_repository.rs
+++ b/maplibre/src/io/tile_repository.rs
@@ -140,13 +140,10 @@ impl TileRepository {
 
     /// Create a new tile.
     pub fn create_tile(&mut self, coords: WorldTileCoords) -> bool {
-        if let Some(entry) = coords.build_quad_key().map(|key| self.tree.entry(key)) {
-            match entry {
-                btree_map::Entry::Vacant(entry) => {
-                    entry.insert(StoredTile::pending(coords));
-                }
-                _ => {}
-            }
+        if let Some(btree_map::Entry::Vacant(entry)) =
+            coords.build_quad_key().map(|key| self.tree.entry(key))
+        {
+            entry.insert(StoredTile::pending(coords));
         }
         true
     }

--- a/maplibre/src/kernel.rs
+++ b/maplibre/src/kernel.rs
@@ -44,6 +44,12 @@ pub struct KernelBuilder<E: Environment> {
     http_client: Option<E::HttpClient>,
 }
 
+impl<E: Environment> Default for KernelBuilder<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<E: Environment> KernelBuilder<E> {
     pub fn new() -> Self {
         Self {

--- a/maplibre/src/platform/noweb/scheduler.rs
+++ b/maplibre/src/platform/noweb/scheduler.rs
@@ -30,3 +30,9 @@ impl Scheduler for TokioScheduler {
         Ok(())
     }
 }
+
+impl Default for TokioScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/maplibre/src/render/builder.rs
+++ b/maplibre/src/render/builder.rs
@@ -110,7 +110,7 @@ impl UninitializedRenderer {
         Ok(Renderer::initialize_headless(
             existing_window,
             self.wgpu_settings.clone(),
-            self.renderer_settings.clone(),
+            self.renderer_settings,
         )
         .await?)
     }

--- a/maplibre/src/render/builder.rs
+++ b/maplibre/src/render/builder.rs
@@ -38,6 +38,12 @@ impl RendererBuilder {
     }
 }
 
+impl Default for RendererBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub enum InitializationResult {
     Initialized(InitializedRenderer),
     Uninizalized(UninitializedRenderer),

--- a/maplibre/src/render/mod.rs
+++ b/maplibre/src/render/mod.rs
@@ -264,11 +264,8 @@ impl Renderer {
         #[cfg(target_arch = "wasm32")]
         let trace_path = None;
 
-        // Maybe get features and limits based on what is supported by the adapter/backend
-        let mut features = wgpu::Features::empty();
-        let mut limits = settings.limits.clone();
-
-        features = adapter.features() | wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
+        let mut features =
+            adapter.features() | wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
         if adapter_info.device_type == wgpu::DeviceType::DiscreteGpu {
             // `MAPPABLE_PRIMARY_BUFFERS` can have a significant, negative performance impact for
             // discrete GPUs due to having to transfer data across the PCI-E bus and so it
@@ -276,7 +273,7 @@ impl Renderer {
             // integrated GPUs.
             features -= wgpu::Features::MAPPABLE_PRIMARY_BUFFERS;
         }
-        limits = adapter.limits();
+        let mut limits = adapter.limits();
 
         // Enforce the disabled features
         if let Some(disabled_features) = settings.disabled_features {

--- a/maplibre/src/render/resource/buffer_pool.rs
+++ b/maplibre/src/render/resource/buffer_pool.rs
@@ -582,6 +582,12 @@ impl RingIndex {
     }
 }
 
+impl Default for RingIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use lyon::tessellation::VertexBuffers;

--- a/maplibre/src/util/fps_meter.rs
+++ b/maplibre/src/util/fps_meter.rs
@@ -37,3 +37,9 @@ impl FPSMeter {
         }
     }
 }
+
+impl Default for FPSMeter {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
Fixes a number of clippy issues:
- Implement `Default` for various types
- Remove some useless format/mut
- Simplify some `if let match`
- Fix some cases where variables are never read because they are immediatly overwritten
