### PR TITLE
justfile: automatically install wasm32 target for nightly toolchain

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,6 +26,8 @@ stable-install-clippy:
 
 nightly-toolchain:
   rustup toolchain install $NIGHTLY_TOOLCHAIN
+  # Without this, build could fail with rust not finding the 'core' crate
+  RUSTUP_TOOLCHAIN=$NIGHTLY_TOOLCHAIN rustup target add wasm32-unknown-unknown
 
 nightly-override-toolchain:
   rustup override set $NIGHTLY_TOOLCHAIN


### PR DESCRIPTION
This fixes an issue where `just web-lib build` would fail because it cannot find the 'core' crate.

I am not sure if this is the right way to fix the problem or the right place, but it worked for me.

## 💻 Examples

```
$ just web-lib build
...
Creating WASM...
   Compiling proc-macro2 v1.0.47
   Compiling unicode-ident v1.0.5
   Compiling quote v1.0.21
   Compiling syn v1.0.103
   Compiling autocfg v1.1.0
   Compiling log v0.4.17
   Compiling cfg-if v1.0.0
error[E0463]: can't find crate for `core`
  |
  = note: the `wasm32-unknown-unknown` target may not be installed
  = help: consider downloading the target with `rustup target add wasm32-unknown-unknown`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`
```

## 🚨 Test instructions

- Check the repo without any nightly rust toolchain installed on Ubuntu 22.04
- Run `just web-lib build`

## ✔️ PR Todo

- [ ] Decide if this is the right place to install this target
- [ ] Should we do the same for the stable toolchain ?
