### PR TITLE
Add MSVC setup to CI

### DIFF
--- a/.github/workflows/demo-windows.yml
+++ b/.github/workflows/demo-windows.yml
@@ -14,6 +14,33 @@ jobs:
       - name: Install mysys2 dependencies
         shell: powershell
         run: pacman -S --noconfirm unzip
+      - name: Setup MSVC
+        run: |
+          $script=@'
+          Push-Location "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build"
+          & "C:\Windows\System32\cmd.exe" /c "vcvars64.bat & set" |
+          ForEach-Object {
+            if ($_ -match "=") {
+              $v = $_.split("=", 2)
+              echo "$v[0]=$v[1]" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+          }
+          Pop-Location
+          '@
+          Out-File -FilePath .\msvc.ps1 -InputObject $script -Encoding utf8
+          & .\msvc.ps1
+      - name: Test MSVC
+        run: |
+          $test_program=@'
+          #include<stdio.h>
+            
+          int main() {
+            printf("Hello World\n");
+            return 0;
+          }
+          '@
+          Out-File -FilePath .\test_program.c -InputObject $test_program -Encoding utf8
+          & cl .\test_program.c
       - name: Show PATH
         shell: powershell
         run: Write-Host $env:path


### PR DESCRIPTION
This setups the MSVC compiler in our CI. Right now we do not need it.

But as soon as we link for example against SQLite or OpenSSL we might need it again.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- explain how these changes can be tested, especially when this affects rendering -->

## ✔️ PR Todo

- [ ] Included links to related issues/PRs
