### PR TITLE
Transform improvements

### DIFF
--- a/.idea/runConfigurations/Serve_Book.xml
+++ b/.idea/runConfigurations/Serve_Book.xml
@@ -7,7 +7,7 @@
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
-    <option name="INTERPRETER_PATH" value="/bin/env" />
+    <option name="INTERPRETER_PATH" value="/usr/bin/env" />
     <option name="INTERPRETER_OPTIONS" value="just --justfile" />
     <option name="EXECUTE_IN_TERMINAL" value="false" />
     <option name="EXECUTE_SCRIPT_FILE" value="true" />

--- a/justfile
+++ b/justfile
@@ -180,6 +180,9 @@ xcodebuild-xcframework:
   echo "$framework_args" | xargs xcodebuild -create-xcframework -output "$XC_FRAMEWORK_PATH"
   cat "$XC_FRAMEWORK_PATH/Info.plist"
 
+book-serve:
+  cd docs && ./generate-summary.sh && mdbook serve
+
 # language=bash
 extract-tiles:
   #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -184,7 +184,7 @@ xcodebuild-xcframework:
     cat "$XC_FRAMEWORK_PATH/Info.plist"
 
 book-serve:
-  cd docs && ./generate-summary.sh && mdbook serve
+    cd docs && ./generate-summary.sh && mdbook serve
 
 # language=bash
 extract-tiles:

--- a/maplibre-winit/src/input/camera_handler.rs
+++ b/maplibre-winit/src/input/camera_handler.rs
@@ -5,27 +5,39 @@ use maplibre::context::MapContext;
 
 use super::UpdateState;
 
-pub struct TiltHandler {
+pub struct CameraHandler {
     delta_pitch: Deg<f64>,
+    delta_roll: Deg<f64>,
+    delta_yaw: Deg<f64>,
 
     speed: f64,
     sensitivity: f64,
 }
 
-impl UpdateState for TiltHandler {
+impl UpdateState for CameraHandler {
     fn update_state(&mut self, MapContext { view_state, .. }: &mut MapContext, dt: Duration) {
         let dt = dt.as_secs_f64() * (1.0 / self.speed);
 
-        let delta = self.delta_pitch * dt;
-        view_state.camera_mut().tilt(delta);
-        self.delta_pitch -= delta;
+        let delta_pitch = self.delta_pitch * dt;
+        view_state.camera_mut().pitch(delta_pitch);
+        self.delta_pitch -= delta_pitch;
+
+        let delta_roll = self.delta_roll * dt;
+        view_state.camera_mut().roll(delta_roll);
+        self.delta_roll -= delta_roll;
+
+        let delta_yaw = self.delta_yaw * dt;
+        view_state.camera_mut().yaw(delta_yaw);
+        self.delta_yaw -= delta_yaw;
     }
 }
 
-impl TiltHandler {
+impl CameraHandler {
     pub fn new(speed: f64, sensitivity: f64) -> Self {
         Self {
             delta_pitch: Deg::zero(),
+            delta_roll: Deg::zero(),
+            delta_yaw: Deg::zero(),
             speed,
             sensitivity,
         }
@@ -48,6 +60,22 @@ impl TiltHandler {
             }
             winit::event::VirtualKeyCode::F => {
                 self.delta_pitch += amount;
+                true
+            }
+            winit::event::VirtualKeyCode::T => {
+                self.delta_yaw -= amount;
+                true
+            }
+            winit::event::VirtualKeyCode::G => {
+                self.delta_yaw += amount;
+                true
+            }
+            winit::event::VirtualKeyCode::Z => {
+                self.delta_roll -= amount;
+                true
+            }
+            winit::event::VirtualKeyCode::H => {
+                self.delta_roll += amount;
                 true
             }
             _ => false,

--- a/maplibre-winit/src/input/camera_handler.rs
+++ b/maplibre-winit/src/input/camera_handler.rs
@@ -1,84 +1,107 @@
 use std::time::Duration;
 
-use cgmath::{Deg, Zero};
+use cgmath::{Deg, MetricSpace, Rad, Vector2};
 use maplibre::context::MapContext;
+use winit::event::{ElementState, MouseButton};
 
 use super::UpdateState;
 
 pub struct CameraHandler {
-    delta_pitch: Deg<f64>,
-    delta_roll: Deg<f64>,
-    delta_yaw: Deg<f64>,
+    window_position: Option<Vector2<f64>>,
+    start_window_position: Option<Vector2<f64>>,
+    is_active: bool,
+    is_middle: bool,
 
-    speed: f64,
+    start_delta_pitch: Option<Rad<f64>>,
+    start_delta_roll: Option<Rad<f64>>,
+    start_delta_yaw: Option<Rad<f64>>,
+
     sensitivity: f64,
 }
 
 impl UpdateState for CameraHandler {
     fn update_state(&mut self, MapContext { view_state, .. }: &mut MapContext, dt: Duration) {
-        let dt = dt.as_secs_f64() * (1.0 / self.speed);
+        if !self.is_active {
+            return;
+        }
 
-        let delta_pitch = self.delta_pitch * dt;
-        view_state.camera_mut().pitch(delta_pitch);
-        self.delta_pitch -= delta_pitch;
+        if let (Some(window_position), Some(start_window_position)) =
+            (self.window_position, self.start_window_position)
+        {
+            let camera = view_state.camera_mut();
 
-        let delta_roll = self.delta_roll * dt;
-        view_state.camera_mut().roll(delta_roll);
-        self.delta_roll -= delta_roll;
+            if self.is_middle {
+                let delta: Rad<_> = (Deg(0.001 * self.sensitivity)
+                    * start_window_position.distance(window_position))
+                .into();
 
-        let delta_yaw = self.delta_yaw * dt;
-        view_state.camera_mut().yaw(delta_yaw);
-        self.delta_yaw -= delta_yaw;
+                let previous = *self.start_delta_roll.get_or_insert(camera.get_roll());
+                camera.set_roll(previous + delta);
+            } else {
+                let delta: Rad<_> = (Deg(0.001 * self.sensitivity)
+                    * (start_window_position.x - window_position.x))
+                    .into();
+                let previous = *self.start_delta_yaw.get_or_insert(camera.get_yaw());
+                camera.set_yaw(previous + delta);
+
+                let delta: Rad<_> = (Deg(0.001 * self.sensitivity)
+                    * (start_window_position.y - window_position.y))
+                    .into();
+                let previous = *self.start_delta_pitch.get_or_insert(camera.get_pitch());
+                camera.set_pitch(previous + delta);
+            }
+        }
     }
 }
 
 impl CameraHandler {
-    pub fn new(speed: f64, sensitivity: f64) -> Self {
+    pub fn new(sensitivity: f64) -> Self {
         Self {
-            delta_pitch: Deg::zero(),
-            delta_roll: Deg::zero(),
-            delta_yaw: Deg::zero(),
-            speed,
+            window_position: None,
+            start_window_position: None,
+            is_active: false,
+            is_middle: false,
+            start_delta_pitch: None,
+            start_delta_roll: None,
+            start_delta_yaw: None,
             sensitivity,
         }
     }
 
-    pub fn process_key_press(
-        &mut self,
-        key: winit::event::VirtualKeyCode,
-        state: winit::event::ElementState,
-    ) -> bool {
-        let amount = if state == winit::event::ElementState::Pressed {
-            Deg(0.1 * self.sensitivity) // left, right is the same as panning 1 degree
+    pub fn process_window_position(&mut self, window_position: &Vector2<f64>, touch: bool) -> bool {
+        if !self.is_active && !touch {
+            self.start_window_position = Some(*window_position);
+            self.window_position = Some(*window_position);
         } else {
-            Deg::zero()
-        };
-        match key {
-            winit::event::VirtualKeyCode::R => {
-                self.delta_pitch -= amount;
-                true
-            }
-            winit::event::VirtualKeyCode::F => {
-                self.delta_pitch += amount;
-                true
-            }
-            winit::event::VirtualKeyCode::T => {
-                self.delta_yaw -= amount;
-                true
-            }
-            winit::event::VirtualKeyCode::G => {
-                self.delta_yaw += amount;
-                true
-            }
-            winit::event::VirtualKeyCode::Z => {
-                self.delta_roll -= amount;
-                true
-            }
-            winit::event::VirtualKeyCode::H => {
-                self.delta_roll += amount;
-                true
-            }
-            _ => false,
+            self.window_position = Some(*window_position);
         }
+
+        true
+    }
+
+    pub fn process_mouse_key_press(&mut self, key: &MouseButton, state: &ElementState) -> bool {
+        if *state == ElementState::Pressed {
+            // currently panning or starting to pan
+            match *key {
+                MouseButton::Right => {
+                    self.is_active = true;
+                }
+                MouseButton::Middle => {
+                    self.is_active = true;
+                    self.is_middle = true;
+                }
+                _ => return false,
+            }
+        } else {
+            // finished panning
+            self.is_active = false;
+            self.is_middle = false;
+            self.start_window_position = None;
+            self.window_position = None;
+            self.start_delta_yaw = None;
+            self.start_delta_pitch = None;
+            self.start_delta_roll = None;
+        }
+        true
     }
 }

--- a/maplibre-winit/src/input/debug_handler.rs
+++ b/maplibre-winit/src/input/debug_handler.rs
@@ -13,7 +13,10 @@ impl UpdateState for DebugHandler {
         let dt = dt.as_secs_f64() * 10.0;
 
         let delta = self.inset_delta * dt;
-        view_state.edge_insets.left += delta;
+
+        let mut edge_insets = *view_state.edge_insets();
+        edge_insets.left += delta;
+        view_state.set_edge_insets(edge_insets);
         self.inset_delta -= delta;
     }
 }

--- a/maplibre-winit/src/input/debug_handler.rs
+++ b/maplibre-winit/src/input/debug_handler.rs
@@ -1,0 +1,44 @@
+use std::time::Duration;
+
+use maplibre::context::MapContext;
+
+use super::UpdateState;
+
+pub struct DebugHandler {
+    inset_delta: f64,
+}
+
+impl UpdateState for DebugHandler {
+    fn update_state(&mut self, MapContext { view_state, .. }: &mut MapContext, dt: Duration) {
+        let dt = dt.as_secs_f64() * 10.0;
+
+        let delta = self.inset_delta * dt;
+        view_state.edge_insets.left += delta;
+        self.inset_delta -= delta;
+    }
+}
+
+impl DebugHandler {
+    pub fn new() -> Self {
+        Self { inset_delta: 0.0 }
+    }
+
+    pub fn process_key_press(
+        &mut self,
+        key: winit::event::VirtualKeyCode,
+        state: winit::event::ElementState,
+    ) -> bool {
+        let amount = if state == winit::event::ElementState::Pressed {
+            100.0 // left, right is the same as panning 1 degree
+        } else {
+            0.0
+        };
+        match key {
+            winit::event::VirtualKeyCode::N => {
+                self.inset_delta += amount;
+                true
+            }
+            _ => false,
+        }
+    }
+}

--- a/maplibre-winit/src/input/debug_handler.rs
+++ b/maplibre-winit/src/input/debug_handler.rs
@@ -32,7 +32,7 @@ impl DebugHandler {
         state: winit::event::ElementState,
     ) -> bool {
         let amount = if state == winit::event::ElementState::Pressed {
-            100.0 // left, right is the same as panning 1 degree
+            100.0
         } else {
             0.0
         };

--- a/maplibre-winit/src/input/debug_handler.rs
+++ b/maplibre-winit/src/input/debug_handler.rs
@@ -5,25 +5,42 @@ use maplibre::context::MapContext;
 use super::UpdateState;
 
 pub struct DebugHandler {
-    inset_delta: f64,
+    top_delta: f64,
+    bottom_delta: f64,
+    left_delta: f64,
+    right_delta: f64,
 }
 
 impl UpdateState for DebugHandler {
     fn update_state(&mut self, MapContext { view_state, .. }: &mut MapContext, dt: Duration) {
         let dt = dt.as_secs_f64() * 10.0;
 
-        let delta = self.inset_delta * dt;
+        let top_delta = self.top_delta * dt;
+        let bottom_delta = self.bottom_delta * dt;
+        let left_delta = self.left_delta * dt;
+        let right_delta = self.right_delta * dt;
 
         let mut edge_insets = *view_state.edge_insets();
-        edge_insets.left += delta;
+        edge_insets.top += top_delta;
+        edge_insets.bottom += bottom_delta;
+        edge_insets.left += left_delta;
+        edge_insets.right += right_delta;
         view_state.set_edge_insets(edge_insets);
-        self.inset_delta -= delta;
+        self.top_delta -= top_delta;
+        self.bottom_delta -= bottom_delta;
+        self.right_delta -= right_delta;
+        self.left_delta -= left_delta;
     }
 }
 
 impl DebugHandler {
     pub fn new() -> Self {
-        Self { inset_delta: 0.0 }
+        Self {
+            top_delta: 0.0,
+            bottom_delta: 0.0,
+            left_delta: 0.0,
+            right_delta: 0.0,
+        }
     }
 
     pub fn process_key_press(
@@ -37,8 +54,20 @@ impl DebugHandler {
             0.0
         };
         match key {
+            winit::event::VirtualKeyCode::V => {
+                self.left_delta += amount;
+                true
+            }
+            winit::event::VirtualKeyCode::B => {
+                self.top_delta += amount;
+                true
+            }
             winit::event::VirtualKeyCode::N => {
-                self.inset_delta += amount;
+                self.bottom_delta += amount;
+                true
+            }
+            winit::event::VirtualKeyCode::M => {
+                self.right_delta += amount;
                 true
             }
             _ => false,

--- a/maplibre-winit/src/input/debug_handler.rs
+++ b/maplibre-winit/src/input/debug_handler.rs
@@ -4,6 +4,7 @@ use maplibre::context::MapContext;
 
 use super::UpdateState;
 
+#[derive(Default)]
 pub struct DebugHandler {
     top_delta: f64,
     bottom_delta: f64,
@@ -34,15 +35,6 @@ impl UpdateState for DebugHandler {
 }
 
 impl DebugHandler {
-    pub fn new() -> Self {
-        Self {
-            top_delta: 0.0,
-            bottom_delta: 0.0,
-            left_delta: 0.0,
-            right_delta: 0.0,
-        }
-    }
-
     pub fn process_key_press(
         &mut self,
         key: winit::event::VirtualKeyCode,

--- a/maplibre-winit/src/input/mod.rs
+++ b/maplibre-winit/src/input/mod.rs
@@ -46,7 +46,7 @@ impl InputController {
             pinch_handler: PinchHandler::new(),
             pan_handler: PanHandler::new(),
             zoom_handler: ZoomHandler::new(zoom_sensitivity),
-            camera_handler: CameraHandler::new(speed, sensitivity),
+            camera_handler: CameraHandler::new(sensitivity),
             shift_handler: ShiftHandler::new(speed, sensitivity),
             query_handler: QueryHandler::new(),
             debug_handler: DebugHandler::new(),
@@ -69,6 +69,8 @@ impl InputController {
                     .process_window_position(&Vector2::from(position), false);
                 self.zoom_handler
                     .process_window_position(&Vector2::from(position), false);
+                self.camera_handler
+                    .process_window_position(&Vector2::from(position), false);
                 true
             }
             WindowEvent::KeyboardInput {
@@ -81,17 +83,17 @@ impl InputController {
                 ..
             } => {
                 if !self.shift_handler.process_key_press(*key, *state) {
-                    if !self.camera_handler.process_key_press(*key, *state) {
+                    if !self.debug_handler.process_key_press(*key, *state) {
                         if !self.zoom_handler.process_key_press(*key, *state) {
-                            self.debug_handler.process_key_press(*key, *state)
-                        } else {
                             false
+                        } else {
+                            true
                         }
                     } else {
-                        false
+                        true
                     }
                 } else {
-                    false
+                    true
                 }
             }
             WindowEvent::Touch(touch) => match touch.phase {
@@ -115,6 +117,8 @@ impl InputController {
                         .process_window_position(&Vector2::from(position), true);
                     self.zoom_handler
                         .process_window_position(&Vector2::from(position), true);
+                    self.camera_handler
+                        .process_window_position(&Vector2::from(position), true);
                     true
                 }
                 TouchPhase::Cancelled => false,
@@ -126,7 +130,9 @@ impl InputController {
             }
             WindowEvent::MouseInput { button, state, .. } => {
                 self.pan_handler.process_mouse_key_press(button, state);
-                self.query_handler.process_mouse_key_press(button, state)
+                self.query_handler.process_mouse_key_press(button, state);
+                self.camera_handler.process_mouse_key_press(button, state);
+                true
             }
             _ => false,
         }

--- a/maplibre-winit/src/input/mod.rs
+++ b/maplibre-winit/src/input/mod.rs
@@ -43,13 +43,13 @@ impl InputController {
     ///
     pub fn new(speed: f64, sensitivity: f64, zoom_sensitivity: f64) -> Self {
         Self {
-            pinch_handler: PinchHandler::new(),
-            pan_handler: PanHandler::new(),
+            pinch_handler: PinchHandler::default(),
+            pan_handler: PanHandler::default(),
             zoom_handler: ZoomHandler::new(zoom_sensitivity),
             camera_handler: CameraHandler::new(sensitivity),
             shift_handler: ShiftHandler::new(speed, sensitivity),
             query_handler: QueryHandler::new(),
-            debug_handler: DebugHandler::new(),
+            debug_handler: DebugHandler::default(),
         }
     }
 
@@ -63,14 +63,12 @@ impl InputController {
         match event {
             WindowEvent::CursorMoved { position, .. } => {
                 let position: (f64, f64) = position.to_owned().into();
-                self.pan_handler
-                    .process_window_position(&Vector2::from(position), false);
-                self.query_handler
-                    .process_window_position(&Vector2::from(position), false);
-                self.zoom_handler
-                    .process_window_position(&Vector2::from(position), false);
+                let position = Vector2::from(position);
+                self.pan_handler.process_window_position(&position, false);
+                self.query_handler.process_window_position(&position, false);
+                self.zoom_handler.process_window_position(&position, false);
                 self.camera_handler
-                    .process_window_position(&Vector2::from(position), false);
+                    .process_window_position(&position, false);
                 true
             }
             WindowEvent::KeyboardInput {
@@ -82,19 +80,9 @@ impl InputController {
                     },
                 ..
             } => {
-                if !self.shift_handler.process_key_press(*key, *state) {
-                    if !self.debug_handler.process_key_press(*key, *state) {
-                        if !self.zoom_handler.process_key_press(*key, *state) {
-                            false
-                        } else {
-                            true
-                        }
-                    } else {
-                        true
-                    }
-                } else {
-                    true
-                }
+                self.shift_handler.process_key_press(*key, *state)
+                    || self.debug_handler.process_key_press(*key, *state)
+                    || self.zoom_handler.process_key_press(*key, *state)
             }
             WindowEvent::Touch(touch) => match touch.phase {
                 TouchPhase::Started => {

--- a/maplibre-winit/src/input/mod.rs
+++ b/maplibre-winit/src/input/mod.rs
@@ -6,10 +6,10 @@ use cgmath::Vector2;
 use maplibre::context::MapContext;
 use winit::event::{DeviceEvent, KeyboardInput, TouchPhase, WindowEvent};
 
-use crate::input::debug_handler::DebugHandler;
 use crate::input::{
-    pan_handler::PanHandler, pinch_handler::PinchHandler, query_handler::QueryHandler,
-    shift_handler::ShiftHandler, tilt_handler::TiltHandler, zoom_handler::ZoomHandler,
+    debug_handler::DebugHandler, pan_handler::PanHandler, pinch_handler::PinchHandler,
+    query_handler::QueryHandler, shift_handler::ShiftHandler, tilt_handler::TiltHandler,
+    zoom_handler::ZoomHandler,
 };
 
 mod debug_handler;

--- a/maplibre-winit/src/input/mod.rs
+++ b/maplibre-winit/src/input/mod.rs
@@ -6,11 +6,13 @@ use cgmath::Vector2;
 use maplibre::context::MapContext;
 use winit::event::{DeviceEvent, KeyboardInput, TouchPhase, WindowEvent};
 
+use crate::input::debug_handler::DebugHandler;
 use crate::input::{
     pan_handler::PanHandler, pinch_handler::PinchHandler, query_handler::QueryHandler,
     shift_handler::ShiftHandler, tilt_handler::TiltHandler, zoom_handler::ZoomHandler,
 };
 
+mod debug_handler;
 mod pan_handler;
 mod pinch_handler;
 mod query_handler;
@@ -25,6 +27,7 @@ pub struct InputController {
     tilt_handler: TiltHandler,
     shift_handler: ShiftHandler,
     query_handler: QueryHandler,
+    debug_handler: DebugHandler,
 }
 
 impl InputController {
@@ -46,6 +49,7 @@ impl InputController {
             tilt_handler: TiltHandler::new(speed, sensitivity),
             shift_handler: ShiftHandler::new(speed, sensitivity),
             query_handler: QueryHandler::new(),
+            debug_handler: DebugHandler::new(),
         }
     }
 
@@ -78,7 +82,11 @@ impl InputController {
             } => {
                 if !self.shift_handler.process_key_press(*key, *state) {
                     if !self.tilt_handler.process_key_press(*key, *state) {
-                        self.zoom_handler.process_key_press(*key, *state)
+                        if !self.zoom_handler.process_key_press(*key, *state) {
+                            self.debug_handler.process_key_press(*key, *state)
+                        } else {
+                            false
+                        }
                     } else {
                         false
                     }
@@ -137,5 +145,6 @@ impl UpdateState for InputController {
         self.tilt_handler.update_state(map_context, dt);
         self.shift_handler.update_state(map_context, dt);
         self.query_handler.update_state(map_context, dt);
+        self.debug_handler.update_state(map_context, dt);
     }
 }

--- a/maplibre-winit/src/input/mod.rs
+++ b/maplibre-winit/src/input/mod.rs
@@ -7,24 +7,24 @@ use maplibre::context::MapContext;
 use winit::event::{DeviceEvent, KeyboardInput, TouchPhase, WindowEvent};
 
 use crate::input::{
-    debug_handler::DebugHandler, pan_handler::PanHandler, pinch_handler::PinchHandler,
-    query_handler::QueryHandler, shift_handler::ShiftHandler, tilt_handler::TiltHandler,
+    camera_handler::CameraHandler, debug_handler::DebugHandler, pan_handler::PanHandler,
+    pinch_handler::PinchHandler, query_handler::QueryHandler, shift_handler::ShiftHandler,
     zoom_handler::ZoomHandler,
 };
 
+mod camera_handler;
 mod debug_handler;
 mod pan_handler;
 mod pinch_handler;
 mod query_handler;
 mod shift_handler;
-mod tilt_handler;
 mod zoom_handler;
 
 pub struct InputController {
     pinch_handler: PinchHandler,
     pan_handler: PanHandler,
     zoom_handler: ZoomHandler,
-    tilt_handler: TiltHandler,
+    camera_handler: CameraHandler,
     shift_handler: ShiftHandler,
     query_handler: QueryHandler,
     debug_handler: DebugHandler,
@@ -46,7 +46,7 @@ impl InputController {
             pinch_handler: PinchHandler::new(),
             pan_handler: PanHandler::new(),
             zoom_handler: ZoomHandler::new(zoom_sensitivity),
-            tilt_handler: TiltHandler::new(speed, sensitivity),
+            camera_handler: CameraHandler::new(speed, sensitivity),
             shift_handler: ShiftHandler::new(speed, sensitivity),
             query_handler: QueryHandler::new(),
             debug_handler: DebugHandler::new(),
@@ -81,7 +81,7 @@ impl InputController {
                 ..
             } => {
                 if !self.shift_handler.process_key_press(*key, *state) {
-                    if !self.tilt_handler.process_key_press(*key, *state) {
+                    if !self.camera_handler.process_key_press(*key, *state) {
                         if !self.zoom_handler.process_key_press(*key, *state) {
                             self.debug_handler.process_key_press(*key, *state)
                         } else {
@@ -142,7 +142,7 @@ impl UpdateState for InputController {
         self.pan_handler.update_state(map_context, dt);
         self.pinch_handler.update_state(map_context, dt);
         self.zoom_handler.update_state(map_context, dt);
-        self.tilt_handler.update_state(map_context, dt);
+        self.camera_handler.update_state(map_context, dt);
         self.shift_handler.update_state(map_context, dt);
         self.query_handler.update_state(map_context, dt);
         self.debug_handler.update_state(map_context, dt);

--- a/maplibre-winit/src/input/pan_handler.rs
+++ b/maplibre-winit/src/input/pan_handler.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use cgmath::{EuclideanSpace, Point2, Vector2, Zero};
-use maplibre::{context::MapContext, render::camera::Camera};
+use maplibre::context::MapContext;
 use winit::event::{ElementState, MouseButton};
 
 use super::UpdateState;
@@ -10,7 +10,6 @@ pub struct PanHandler {
     window_position: Option<Vector2<f64>>,
     start_window_position: Option<Vector2<f64>>,
     start_camera_position: Option<Vector2<f64>>,
-    reference_camera: Option<Camera>,
     is_panning: bool,
 }
 
@@ -20,42 +19,34 @@ impl UpdateState for PanHandler {
             return;
         }
 
-        if let Some(reference_camera) = &self.reference_camera {
-            if let (Some(window_position), Some(start_window_position)) =
-                (self.window_position, self.start_window_position)
-            {
-                let view_proj = view_state.view_projection();
-                let inverted_view_proj = view_proj.invert();
+        if let (Some(window_position), Some(start_window_position)) =
+            (self.window_position, self.start_window_position)
+        {
+            let view_proj = view_state.view_projection();
+            let inverted_view_proj = view_proj.invert();
 
-                let delta = if let (Some(start), Some(current)) = (
-                    view_state.window_to_world_at_ground(
-                        &start_window_position,
-                        &inverted_view_proj,
-                        false,
-                    ),
-                    view_state.window_to_world_at_ground(
-                        &window_position,
-                        &inverted_view_proj,
-                        false,
-                    ),
-                ) {
-                    start - current
-                } else {
-                    Vector2::zero()
-                };
+            let delta = if let (Some(start), Some(current)) = (
+                view_state.window_to_world_at_ground(
+                    &start_window_position,
+                    &inverted_view_proj,
+                    false,
+                ),
+                view_state.window_to_world_at_ground(&window_position, &inverted_view_proj, false),
+            ) {
+                start - current
+            } else {
+                Vector2::zero()
+            };
 
-                if self.start_camera_position.is_none() {
-                    self.start_camera_position = Some(view_state.camera().position().to_vec());
-                }
-
-                if let Some(start_camera_position) = self.start_camera_position {
-                    view_state.camera_mut().move_to(Point2::from_vec(
-                        start_camera_position + Vector2::new(delta.x, delta.y),
-                    ));
-                }
+            if self.start_camera_position.is_none() {
+                self.start_camera_position = Some(view_state.camera().position().to_vec());
             }
-        } else {
-            self.reference_camera = Some(view_state.camera().clone());
+
+            if let Some(start_camera_position) = self.start_camera_position {
+                view_state.camera_mut().move_to(Point2::from_vec(
+                    start_camera_position + Vector2::new(delta.x, delta.y),
+                ));
+            }
         }
     }
 }
@@ -66,7 +57,6 @@ impl PanHandler {
             window_position: None,
             start_window_position: None,
             start_camera_position: None,
-            reference_camera: None,
             is_panning: false,
         }
     }
@@ -81,7 +71,6 @@ impl PanHandler {
         self.start_camera_position = None;
         self.start_window_position = None;
         self.window_position = None;
-        self.reference_camera = None;
         self.is_panning = false;
         true
     }
@@ -110,7 +99,6 @@ impl PanHandler {
             self.start_camera_position = None;
             self.start_window_position = None;
             self.window_position = None;
-            self.reference_camera = None;
             self.is_panning = false;
         }
         true

--- a/maplibre-winit/src/input/pan_handler.rs
+++ b/maplibre-winit/src/input/pan_handler.rs
@@ -6,6 +6,7 @@ use winit::event::{ElementState, MouseButton};
 
 use super::UpdateState;
 
+#[derive(Default)]
 pub struct PanHandler {
     window_position: Option<Vector2<f64>>,
     start_window_position: Option<Vector2<f64>>,
@@ -52,15 +53,6 @@ impl UpdateState for PanHandler {
 }
 
 impl PanHandler {
-    pub fn new() -> Self {
-        Self {
-            window_position: None,
-            start_window_position: None,
-            start_camera_position: None,
-            is_panning: false,
-        }
-    }
-
     pub fn process_touch_start(&mut self, window_position: &Vector2<f64>) -> bool {
         self.is_panning = true;
         self.start_window_position = Some(*window_position);

--- a/maplibre-winit/src/input/pan_handler.rs
+++ b/maplibre-winit/src/input/pan_handler.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use cgmath::{EuclideanSpace, Point3, Vector2, Vector3, Zero};
+use cgmath::{EuclideanSpace, Point2, Vector2, Zero};
 use maplibre::{context::MapContext, render::camera::Camera};
 use winit::event::{ElementState, MouseButton};
 
@@ -9,7 +9,7 @@ use super::UpdateState;
 pub struct PanHandler {
     window_position: Option<Vector2<f64>>,
     start_window_position: Option<Vector2<f64>>,
-    start_camera_position: Option<Vector3<f64>>,
+    start_camera_position: Option<Vector2<f64>>,
     reference_camera: Option<Camera>,
     is_panning: bool,
 }
@@ -41,7 +41,7 @@ impl UpdateState for PanHandler {
                 ) {
                     start - current
                 } else {
-                    Vector3::zero()
+                    Vector2::zero()
                 };
 
                 if self.start_camera_position.is_none() {
@@ -49,8 +49,8 @@ impl UpdateState for PanHandler {
                 }
 
                 if let Some(start_camera_position) = self.start_camera_position {
-                    view_state.camera_mut().move_to(Point3::from_vec(
-                        start_camera_position + Vector3::new(delta.x, delta.y, 0.0),
+                    view_state.camera_mut().move_to(Point2::from_vec(
+                        start_camera_position + Vector2::new(delta.x, delta.y),
                     ));
                 }
             }

--- a/maplibre-winit/src/input/pan_handler.rs
+++ b/maplibre-winit/src/input/pan_handler.rs
@@ -28,12 +28,12 @@ impl UpdateState for PanHandler {
                 let inverted_view_proj = view_proj.invert();
 
                 let delta = if let (Some(start), Some(current)) = (
-                    reference_camera.window_to_world_at_ground(
+                    view_state.window_to_world_at_ground(
                         &start_window_position,
                         &inverted_view_proj,
                         false,
                     ),
-                    reference_camera.window_to_world_at_ground(
+                    view_state.window_to_world_at_ground(
                         &window_position,
                         &inverted_view_proj,
                         false,

--- a/maplibre-winit/src/input/pinch_handler.rs
+++ b/maplibre-winit/src/input/pinch_handler.rs
@@ -4,16 +4,11 @@ use maplibre::context::MapContext;
 
 use super::UpdateState;
 
+#[derive(Default)]
 pub struct PinchHandler {}
 
 impl UpdateState for PinchHandler {
     fn update_state(&mut self, _map_context: &mut MapContext, _dt: Duration) {
         // TODO
-    }
-}
-
-impl PinchHandler {
-    pub fn new() -> Self {
-        Self {}
     }
 }

--- a/maplibre-winit/src/input/query_handler.rs
+++ b/maplibre-winit/src/input/query_handler.rs
@@ -2,9 +2,8 @@ use std::time::Duration;
 
 use cgmath::Vector2;
 use maplibre::{
-    context::MapContext,
-    coords::{WorldCoords, TILE_SIZE},
-    io::geometry_index::IndexedGeometry,
+    context::MapContext, coords::WorldCoords, io::geometry_index::IndexedGeometry,
+    render::tile_view_pattern::DEFAULT_TILE_SIZE,
 };
 use winit::event::{ElementState, MouseButton};
 
@@ -69,7 +68,7 @@ impl UpdateState for QueryHandler {
                 let view_proj = view_state.view_projection();
                 let inverted_view_proj = view_proj.invert();
 
-                let z = view_state.zoom().zoom_level(TILE_SIZE); // FIXME: can be wrong, if tiles of different z are visible
+                let z = view_state.zoom().zoom_level(DEFAULT_TILE_SIZE); // FIXME: can be wrong, if tiles of different z are visible
                 let zoom = view_state.zoom();
 
                 if let Some(coordinates) = view_state.camera().window_to_world_at_ground(

--- a/maplibre-winit/src/input/query_handler.rs
+++ b/maplibre-winit/src/input/query_handler.rs
@@ -1,7 +1,11 @@
 use std::time::Duration;
 
 use cgmath::Vector2;
-use maplibre::{context::MapContext, coords::WorldCoords, io::geometry_index::IndexedGeometry};
+use maplibre::{
+    context::MapContext,
+    coords::{WorldCoords, TILE_SIZE},
+    io::geometry_index::IndexedGeometry,
+};
 use winit::event::{ElementState, MouseButton};
 
 use crate::input::UpdateState;
@@ -65,7 +69,7 @@ impl UpdateState for QueryHandler {
                 let view_proj = view_state.view_projection();
                 let inverted_view_proj = view_proj.invert();
 
-                let z = view_state.visible_level(); // FIXME: can be wrong, if tiles of different z are visible
+                let z = view_state.zoom().zoom_level(TILE_SIZE); // FIXME: can be wrong, if tiles of different z are visible
                 let zoom = view_state.zoom();
 
                 if let Some(coordinates) = view_state.camera().window_to_world_at_ground(

--- a/maplibre-winit/src/input/query_handler.rs
+++ b/maplibre-winit/src/input/query_handler.rs
@@ -71,7 +71,7 @@ impl UpdateState for QueryHandler {
                 let z = view_state.zoom().zoom_level(DEFAULT_TILE_SIZE); // FIXME: can be wrong, if tiles of different z are visible
                 let zoom = view_state.zoom();
 
-                if let Some(coordinates) = view_state.camera().window_to_world_at_ground(
+                if let Some(coordinates) = view_state.window_to_world_at_ground(
                     &window_position,
                     &inverted_view_proj,
                     false,

--- a/maplibre-winit/src/input/shift_handler.rs
+++ b/maplibre-winit/src/input/shift_handler.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
-use cgmath::{Vector3, Zero};
+use cgmath::{Vector2, Zero};
 use maplibre::context::MapContext;
 
 use super::UpdateState;
 
 pub struct ShiftHandler {
-    camera_translate: Vector3<f64>,
+    camera_translate: Vector2<f64>,
 
     speed: f64,
     sensitivity: f64,
@@ -25,7 +25,7 @@ impl UpdateState for ShiftHandler {
 impl ShiftHandler {
     pub fn new(speed: f64, sensitivity: f64) -> Self {
         Self {
-            camera_translate: Vector3::zero(),
+            camera_translate: Vector2::zero(),
             speed,
             sensitivity,
         }

--- a/maplibre-winit/src/input/zoom_handler.rs
+++ b/maplibre-winit/src/input/zoom_handler.rs
@@ -24,7 +24,7 @@ impl UpdateState for ZoomHandler {
                 let view_proj = view_state.view_projection();
                 let inverted_view_proj = view_proj.invert();
 
-                if let Some(cursor_position) = view_state.camera().window_to_world_at_ground(
+                if let Some(cursor_position) = view_state.window_to_world_at_ground(
                     &window_position,
                     &inverted_view_proj,
                     false,

--- a/maplibre-winit/src/input/zoom_handler.rs
+++ b/maplibre-winit/src/input/zoom_handler.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use cgmath::{Vector2, Vector3};
+use cgmath::Vector2;
 use maplibre::{context::MapContext, coords::Zoom};
 
 use super::UpdateState;
@@ -31,11 +31,8 @@ impl UpdateState for ZoomHandler {
                 ) {
                     let scale = current_zoom.scale_delta(&next_zoom);
 
-                    let delta = Vector3::new(
-                        cursor_position.x * scale,
-                        cursor_position.y * scale,
-                        cursor_position.z,
-                    ) - cursor_position;
+                    let delta = Vector2::new(cursor_position.x * scale, cursor_position.y * scale)
+                        - cursor_position;
 
                     view_state.camera_mut().move_relative(delta);
                 }

--- a/maplibre-winit/src/noweb.rs
+++ b/maplibre-winit/src/noweb.rs
@@ -6,7 +6,6 @@
 use std::marker::PhantomData;
 
 use maplibre::{
-    debug::DebugPlugin,
     event_loop::EventLoop,
     io::apc::SchedulerAsyncProcedureCall,
     kernel::{Kernel, KernelBuilder},
@@ -102,7 +101,8 @@ pub fn run_headed_map(cache_path: Option<String>) {
                 Box::new(RenderPlugin::default()),
                 //Box::new(VectorPlugin::<DefaultVectorTransferables>::default()),
                 Box::new(RasterPlugin::<DefaultRasterTransferables>::default()),
-                Box::new(DebugPlugin::default()),
+                #[cfg(debug_assertions)]
+                Box::new(maplibre::debug::DebugPlugin::default()),
             ],
         )
         .unwrap();

--- a/maplibre/src/context.rs
+++ b/maplibre/src/context.rs
@@ -1,5 +1,8 @@
-use crate::render::view_state::ViewState;
-use crate::{render::Renderer, style::Style, tcs::world::World};
+use crate::{
+    render::{view_state::ViewState, Renderer},
+    style::Style,
+    tcs::world::World,
+};
 
 /// Stores the context of the map.
 ///

--- a/maplibre/src/context.rs
+++ b/maplibre/src/context.rs
@@ -1,4 +1,5 @@
-use crate::{render::Renderer, style::Style, tcs::world::World, view_state::ViewState};
+use crate::render::view_state::ViewState;
+use crate::{render::Renderer, style::Style, tcs::world::World};
 
 /// Stores the context of the map.
 ///

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -221,6 +221,8 @@ impl Zoom {
         2.0_f64.powf(zoom.0 - self.0)
     }
 
+    /// Adopted from
+    /// [Transform::coveringZoomLevel](https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L279-L288)
     pub fn zoom_level(&self, tile_size: f64) -> ZoomLevel {
         // TODO: Also support round() instead of floor() here
         let z = (self.0 as f64 + (TILE_SIZE / tile_size).ln() / 2.0_f64.ln()).floor() as u8;
@@ -358,6 +360,8 @@ impl WorldTileCoords {
         })
     }
 
+    /// Adopted from
+    /// [Transform::calculatePosMatrix](https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L719-L731)
     #[tracing::instrument(skip_all)]
     pub fn transform_for_zoom(&self, zoom: Zoom) -> Matrix4<f64> {
         /*

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -147,20 +147,16 @@ impl LatLon {
         }
     }
 
-    /*
-     * Approximate radius of the earth in meters.
-     * Uses the WGS-84 approximation. The radius at the equator is ~6378137 and at the poles is ~6356752. https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84
-     * 6371008.8 is one published "average radius" see https://en.wikipedia.org/wiki/Earth_radius#Mean_radius, or ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf p.4
-     */
+    /// Approximate radius of the earth in meters.
+    /// Uses the WGS-84 approximation. The radius at the equator is ~6378137 and at the poles is ~6356752. https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84
+    /// 6371008.8 is one published "average radius" see https://en.wikipedia.org/wiki/Earth_radius#Mean_radius, or ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf p.4
     const EARTH_RADIUS: f64 = 6371008.8;
-    /*
-     * The average circumference of the world in meters.
-     */
+
+    /// The average circumference of the world in meters.
+
     const EARTH_CIRCUMFRENCE: f64 = 2.0 * PI * Self::EARTH_RADIUS; // meters
 
-    /*
-     * The circumference at a line of latitude in meters.
-     */
+    /// The circumference at a line of latitude in meters.
     fn circumference_at_latitude(&self) -> f64 {
         Self::EARTH_CIRCUMFRENCE * (self.latitude * PI / 180.0).cos()
     }

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -146,6 +146,36 @@ impl LatLon {
             longitude,
         }
     }
+
+    /*
+     * Approximate radius of the earth in meters.
+     * Uses the WGS-84 approximation. The radius at the equator is ~6378137 and at the poles is ~6356752. https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84
+     * 6371008.8 is one published "average radius" see https://en.wikipedia.org/wiki/Earth_radius#Mean_radius, or ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf p.4
+     */
+    const EARTH_RADIUS: f64 = 6371008.8;
+    /*
+     * The average circumference of the world in meters.
+     */
+    const EARTH_CIRCUMFRENCE: f64 = 2.0 * PI * Self::EARTH_RADIUS; // meters
+
+    /*
+     * The circumference at a line of latitude in meters.
+     */
+    fn circumference_at_latitude(&self) -> f64 {
+        Self::EARTH_CIRCUMFRENCE * (self.latitude * PI / 180.0).cos()
+    }
+
+    fn mercator_x_from_lng(&self) -> f64 {
+        (180.0 + self.longitude) / 360.0
+    }
+
+    fn mercator_y_from_lat(&self) -> f64 {
+        (180.0 - (180.0 / PI * ((PI / 4.0 + self.latitude * PI / 360.0).tan()).ln())) / 360.0
+    }
+
+    fn mercator_z_from_altitude(&self, altitude: f64) -> f64 {
+        altitude / self.circumference_at_latitude()
+    }
 }
 
 impl Default for LatLon {

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -729,6 +729,7 @@ mod tests {
         coords::{
             Quadkey, TileCoords, ViewRegion, WorldCoords, WorldTileCoords, Zoom, ZoomLevel, EXTENT,
         },
+        render::tile_view_pattern::DEFAULT_TILE_SIZE,
         style::source::TileAddressingScheme,
         util::math::Aabb2,
     };

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -221,8 +221,10 @@ impl Zoom {
         2.0_f64.powf(zoom.0 - self.0)
     }
 
-    pub fn level(&self) -> ZoomLevel {
-        ZoomLevel::from(self.0.floor() as u8)
+    pub fn zoom_level(&self, tile_size: f64) -> ZoomLevel {
+        // TODO: Also support round() instead of floor() here
+        let z = (self.0 as f64 + (TILE_SIZE / tile_size).ln() / 2.0_f64.ln()).floor() as u8;
+        return ZoomLevel(z.max(0));
     }
 }
 
@@ -704,7 +706,7 @@ mod tests {
         println!("{:?}\n{:?}", p1, p2);
 
         assert_eq!(
-            WorldCoords::from((p1.x, p1.y)).into_world_tile(zoom.level(), zoom),
+            WorldCoords::from((p1.x, p1.y)).into_world_tile(zoom.zoom_level(), zoom),
             tile
         );
     }

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -223,6 +223,11 @@ impl Zoom {
 
     /// Adopted from
     /// [Transform::coveringZoomLevel](https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L279-L288)
+    ///
+    /// The `tile_size` is the size of the tile like specified in the source definition,
+    /// For example raster tiles can be 512px or 256px. If it is 256px, then 2x as many tiles are
+    /// displayed. If the raster tile is 512px then exactly as many raster tiles like vector
+    /// tiles would be displayed.
     pub fn zoom_level(&self, tile_size: f64) -> ZoomLevel {
         // TODO: Also support round() instead of floor() here
         let z = (self.0 as f64 + (TILE_SIZE / tile_size).ln() / 2.0_f64.ln()).floor() as u8;
@@ -695,6 +700,7 @@ mod tests {
     use crate::{
         coords::{
             Quadkey, TileCoords, ViewRegion, WorldCoords, WorldTileCoords, Zoom, ZoomLevel, EXTENT,
+            TILE_SIZE,
         },
         style::source::TileAddressingScheme,
         util::math::Aabb2,
@@ -710,7 +716,7 @@ mod tests {
         println!("{:?}\n{:?}", p1, p2);
 
         assert_eq!(
-            WorldCoords::from((p1.x, p1.y)).into_world_tile(zoom.zoom_level(), zoom),
+            WorldCoords::from((p1.x, p1.y)).into_world_tile(zoom.zoom_level(TILE_SIZE), zoom),
             tile
         );
     }

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -224,6 +224,8 @@ impl Zoom {
     /// Adopted from
     /// [Transform::coveringZoomLevel](https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L279-L288)
     ///
+    /// This function calculates which ZoomLevel to show at this zoom.
+    ///
     /// The `tile_size` is the size of the tile like specified in the source definition,
     /// For example raster tiles can be 512px or 256px. If it is 256px, then 2x as many tiles are
     /// displayed. If the raster tile is 512px then exactly as many raster tiles like vector
@@ -700,7 +702,6 @@ mod tests {
     use crate::{
         coords::{
             Quadkey, TileCoords, ViewRegion, WorldCoords, WorldTileCoords, Zoom, ZoomLevel, EXTENT,
-            TILE_SIZE,
         },
         style::source::TileAddressingScheme,
         util::math::Aabb2,
@@ -716,7 +717,8 @@ mod tests {
         println!("{:?}\n{:?}", p1, p2);
 
         assert_eq!(
-            WorldCoords::from((p1.x, p1.y)).into_world_tile(zoom.zoom_level(TILE_SIZE), zoom),
+            WorldCoords::from((p1.x, p1.y))
+                .into_world_tile(zoom.zoom_level(DEFAULT_TILE_SIZE), zoom),
             tile
         );
     }

--- a/maplibre/src/headless/map.rs
+++ b/maplibre/src/headless/map.rs
@@ -44,7 +44,7 @@ impl HeadlessMap {
             WorldCoords::from((TILE_SIZE / 2., TILE_SIZE / 2.)),
             Zoom::default(),
             cgmath::Deg(0.0),
-            cgmath::Deg(110.0),
+            cgmath::Rad(0.6435011087932844),
         );
 
         let mut world = World::default();

--- a/maplibre/src/headless/map.rs
+++ b/maplibre/src/headless/map.rs
@@ -12,7 +12,7 @@ use crate::{
     kernel::Kernel,
     map::MapError,
     plugin::Plugin,
-    render::{eventually::Eventually, Renderer},
+    render::{eventually::Eventually, view_state::ViewState, Renderer},
     schedule::{Schedule, Stage},
     style::Style,
     tcs::world::World,
@@ -21,7 +21,6 @@ use crate::{
         LayerTessellated, ProcessVectorContext, VectorBufferPool, VectorLayerData,
         VectorLayersDataComponent, VectorTileRequest, VectorTransferables,
     },
-    view_state::ViewState,
 };
 
 pub struct HeadlessMap {

--- a/maplibre/src/lib.rs
+++ b/maplibre/src/lib.rs
@@ -51,7 +51,6 @@ pub mod kernel;
 pub mod map;
 pub mod plugin;
 pub mod tcs;
-pub mod view_state;
 
 // Plugins
 pub mod debug;

--- a/maplibre/src/map.rs
+++ b/maplibre/src/map.rs
@@ -2,7 +2,6 @@ use std::rc::Rc;
 
 use thiserror::Error;
 
-use crate::render::view_state::ViewState;
 use crate::{
     context::MapContext,
     coords::{LatLon, WorldCoords, Zoom},
@@ -15,6 +14,7 @@ use crate::{
         },
         error::RenderError,
         graph::RenderGraphError,
+        view_state::ViewState,
     },
     schedule::{Schedule, Stage},
     style::Style,

--- a/maplibre/src/map.rs
+++ b/maplibre/src/map.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 
 use thiserror::Error;
 
+use crate::render::view_state::ViewState;
 use crate::{
     context::MapContext,
     coords::{LatLon, WorldCoords, Zoom},
@@ -18,7 +19,6 @@ use crate::{
     schedule::{Schedule, Stage},
     style::Style,
     tcs::world::World,
-    view_state::ViewState,
     window::{HeadedMapWindow, MapWindow, MapWindowConfig},
 };
 

--- a/maplibre/src/map.rs
+++ b/maplibre/src/map.rs
@@ -102,7 +102,7 @@ where
                     WorldCoords::from_lat_lon(LatLon::new(center[0], center[1]), initial_zoom),
                     initial_zoom,
                     cgmath::Deg::<f64>(style.pitch.unwrap_or_default()),
-                    cgmath::Deg(110.0),
+                    cgmath::Rad(0.6435011087932844),
                 );
 
                 let mut world = World::default();

--- a/maplibre/src/raster/request_system.rs
+++ b/maplibre/src/raster/request_system.rs
@@ -15,6 +15,7 @@ use crate::{
         transferables::{LayerRasterMissing, RasterTransferables},
         RasterLayersDataComponent,
     },
+    render::tile_view_pattern::DEFAULT_TILE_SIZE,
     style::layer::LayerPaint,
     tcs::system::System,
 };
@@ -48,7 +49,8 @@ impl<E: Environment, T: RasterTransferables> System for RequestSystem<E, T> {
         }: &mut MapContext,
     ) {
         let _tiles = &mut world.tiles;
-        let view_region = view_state.create_view_region();
+        let view_region =
+            view_state.create_view_region(view_state.zoom().zoom_level(DEFAULT_TILE_SIZE));
 
         if view_state.did_camera_change() || view_state.did_zoom_change() {
             if let Some(view_region) = &view_region {

--- a/maplibre/src/raster/upload_system.rs
+++ b/maplibre/src/raster/upload_system.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     render::{
         eventually::{Eventually, Eventually::Initialized},
+        tile_view_pattern::DEFAULT_TILE_SIZE,
         Renderer,
     },
     style::Style,
@@ -26,7 +27,8 @@ pub fn upload_system(
     let Some(Initialized(raster_resources)) = world
         .resources
         .query_mut::<&mut Eventually<RasterResources>>() else { return; };
-    let view_region = view_state.create_view_region();
+    let view_region =
+        view_state.create_view_region(view_state.zoom().zoom_level(DEFAULT_TILE_SIZE));
 
     if let Some(view_region) = &view_region {
         upload_raster_layer(

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -65,11 +65,11 @@ impl ModelViewProjection {
     }
 }
 
-const MIN_PITCH: Deg<f64> = Deg(-90.0);
-const MAX_PITCH: Deg<f64> = Deg(90.0);
+const MIN_PITCH: Deg<f64> = Deg(-30.0);
+const MAX_PITCH: Deg<f64> = Deg(30.0);
 
-const MIN_YAW: Deg<f64> = Deg(-90.0);
-const MAX_YAW: Deg<f64> = Deg(90.0);
+const MIN_YAW: Deg<f64> = Deg(-30.0);
+const MAX_YAW: Deg<f64> = Deg(30.0);
 
 #[derive(Debug, Clone)]
 pub struct Camera {
@@ -167,7 +167,7 @@ impl Camera {
         let new_yaw = yaw.into();
         let max: Rad<_> = MAX_YAW.into();
         let min: Rad<_> = MIN_YAW.into();
-        //self.yaw = Rad(new_yaw.0.min(max.0).max(min.0))
+        self.yaw = Rad(new_yaw.0.min(max.0).max(min.0))
     }
     pub fn set_pitch<P: Into<Rad<f64>>>(&mut self, pitch: P) {
         let new_pitch = pitch.into();

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -97,6 +97,7 @@ impl Camera {
     }
 
     pub fn calc_matrix(&self, camera_height: f64) -> Matrix4<f64> {
+        // Matrix4::from_nonuniform_scale(1.0, -1.0, 1.0) *
         Matrix4::from_translation(Vector3::new(0.0, 0.0, -camera_height))
             * Matrix4::from_angle_x(self.pitch)
             * Matrix4::from_translation(Vector3::new(-self.position.x, -self.position.y, 0.0))
@@ -204,8 +205,13 @@ impl Perspective {
         let xmax = ymax * aspect;
 
         // https://webglfundamentals.org/webgl/lessons/webgl-qna-how-can-i-move-the-perspective-vanishing-point-from-the-center-of-the-canvas-.html
-        let off_x = -center_offset.x * (xmax * 2.0) / width;
-        let off_y = center_offset.y * (ymax * 2.0) / height;
+        let near_width = xmax * 2.0;
+        let near_height = ymax * 2.0;
+        let screen_to_near_factor_x = near_width / width;
+        let screen_to_near_factor_y = near_height / height;
+
+        let off_x = -center_offset.x * screen_to_near_factor_x;
+        let off_y = center_offset.y * screen_to_near_factor_y;
 
         frustum(
             -xmax + off_x,

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -97,13 +97,9 @@ impl Camera {
     }
 
     pub fn calc_matrix(&self, camera_height: f64) -> Matrix4<f64> {
-        let (sin_pitch, cos_pitch) = self.pitch.sin_cos();
-        let (sin_yaw, cos_yaw) = self.yaw.sin_cos();
-        Matrix4::look_to_rh(
-            self.to_3d(camera_height),
-            Vector3::new(cos_pitch * cos_yaw, sin_pitch, cos_pitch * sin_yaw).normalize(),
-            Vector3::unit_y(),
-        )
+        Matrix4::from_translation(Vector3::new(0.0, 0.0, -camera_height))
+            * Matrix4::from_angle_x(self.pitch)
+            * Matrix4::from_translation(Vector3::new(-self.position.x, -self.position.y, 0.0))
     }
 
     pub fn position(&self) -> Point2<f64> {

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -97,9 +97,11 @@ impl Camera {
     }
 
     pub fn calc_matrix(&self, camera_height: f64) -> Matrix4<f64> {
+        let (sin_pitch, cos_pitch) = self.pitch.sin_cos();
+        let (sin_yaw, cos_yaw) = self.yaw.sin_cos();
         Matrix4::look_to_rh(
             self.to_3d(camera_height),
-            Vector3::new(self.yaw.cos(), self.pitch.sin(), self.yaw.sin()).normalize(),
+            Vector3::new(cos_pitch * cos_yaw, sin_pitch, cos_pitch * sin_yaw).normalize(),
             Vector3::unit_y(),
         )
     }

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -1,7 +1,8 @@
 //! Main camera
 
-use cgmath::{num_traits::clamp, prelude::*, *};
 use std::convert::Into;
+
+use cgmath::{num_traits::clamp, prelude::*, *};
 
 use crate::util::SignificantlyDifferent;
 

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -68,7 +68,7 @@ const MAX_PITCH: Rad<f64> = Rad(0.5);
 
 #[derive(Debug, Clone)]
 pub struct Camera {
-    position: Point3<f64>, // The z axis never changes, the zoom is used instead
+    position: Point2<f64>,
     yaw: Rad<f64>,
     pitch: Rad<f64>,
 }
@@ -84,7 +84,7 @@ impl SignificantlyDifferent for Camera {
 }
 
 impl Camera {
-    pub fn new<V: Into<Point3<f64>>, Y: Into<Rad<f64>>, P: Into<Rad<f64>>>(
+    pub fn new<V: Into<Point2<f64>>, Y: Into<Rad<f64>>, P: Into<Rad<f64>>>(
         position: V,
         yaw: Y,
         pitch: P,
@@ -96,15 +96,15 @@ impl Camera {
         }
     }
 
-    pub fn calc_matrix(&self) -> Matrix4<f64> {
+    pub fn calc_matrix(&self, camera_height: f64) -> Matrix4<f64> {
         Matrix4::look_to_rh(
-            self.position,
+            self.to_3d(camera_height),
             Vector3::new(self.yaw.cos(), self.pitch.sin(), self.yaw.sin()).normalize(),
             Vector3::unit_y(),
         )
     }
 
-    pub fn position(&self) -> Point3<f64> {
+    pub fn position(&self) -> Point2<f64> {
         self.position
     }
 
@@ -128,20 +128,20 @@ impl Camera {
         }
     }
 
-    pub fn move_relative(&mut self, delta: Vector3<f64>) {
+    pub fn move_relative(&mut self, delta: Vector2<f64>) {
         self.position += delta;
     }
 
-    pub fn move_to(&mut self, new_position: Point3<f64>) {
+    pub fn move_to(&mut self, new_position: Point2<f64>) {
         self.position = new_position;
     }
 
-    pub fn position_vector(&self) -> Vector3<f64> {
+    pub fn position_vector(&self) -> Vector2<f64> {
         self.position.to_vec()
     }
 
-    pub fn homogenous_position(&self) -> Vector4<f64> {
-        self.position.to_homogeneous()
+    pub fn to_3d(&self, camera_height: f64) -> Point3<f64> {
+        Point3::new(self.position.x, self.position.y, camera_height)
     }
 }
 

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -7,12 +7,9 @@ use cgmath::{
     Vector4,
 };
 
-use crate::{
-    coords::TILE_SIZE,
-    util::{
-        math::{bounds_from_points, Aabb2, Aabb3, Plane},
-        SignificantlyDifferent,
-    },
+use crate::util::{
+    math::{bounds_from_points, Aabb2, Aabb3, Plane},
+    SignificantlyDifferent,
 };
 
 #[rustfmt::skip]
@@ -402,14 +399,12 @@ impl Camera {
 
 pub struct Perspective {
     fovy: Rad<f64>,
-    znear: f64,
-    zfar: f64,
 
     current_projection: Matrix4<f64>,
 }
 
 impl Perspective {
-    pub fn new<F: Into<Rad<f64>>>(width: u32, height: u32, fovy: F, znear: f64, zfar: f64) -> Self {
+    pub fn new<F: Into<Rad<f64>>>(width: u32, height: u32, fovy: F) -> Self {
         let rad = fovy.into();
         Self {
             current_projection: Self::calc_matrix(
@@ -417,12 +412,8 @@ impl Perspective {
                 width as f64,
                 height as f64,
                 rad,
-                znear,
-                zfar,
             ),
             fovy: rad,
-            znear,
-            zfar,
         }
     }
 
@@ -432,29 +423,17 @@ impl Perspective {
             width as f64,
             height as f64,
             self.fovy,
-            self.znear,
-            self.zfar,
         );
     }
 
-    fn calc_matrix(
-        aspect: f64,
-        width: f64,
-        height: f64,
-        fovy: Rad<f64>,
-        znear: f64,
-        zfar: f64,
-    ) -> Matrix4<f64> {
-        // Adopted from https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L827-L879
-        let _fov: f64 = 0.6435011087932844;
-        let _pitch = 0.0; // TODO
+    // Adopted from https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L827-L879
+    fn calc_matrix(aspect: f64, width: f64, height: f64, fovy: Rad<f64>) -> Matrix4<f64> {
+        let pitch = 0.0; // FIXME: We need pitch to calculate `furthest_distance`
 
-        let center_point = Point2::new(width / 2.0, height / 2.0); // TODO: honor insets
-        let center_offset_x = center_point.x - width / 2.0;
+        let center_point = Point2::new(width / 2.0, height / 2.0);
         let center_offset_y = center_point.y - height / 2.0;
 
-        let half_fov = _fov / 2.0;
-        let offset_x = center_offset_x;
+        let half_fov = fovy / 2.0;
         let offset_y = center_offset_y;
         let camera_to_center_distance = 0.5 / half_fov.tan() * height;
 
@@ -462,36 +441,40 @@ impl Perspective {
         // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
         // 1 Z unit is equivalent to 1 horizontal px at the center of the map
         // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
-        let ground_angle = PI / 2.0 + _pitch;
-        let fov_above_center = _fov * (0.5 + offset_y / height);
+        let ground_angle = PI / 2.0 + pitch;
+        let fov_above_center = fovy.0 * (0.5 + offset_y / height);
         let top_half_surface_distance = fov_above_center.sin() * camera_to_center_distance
             / clamp(PI - ground_angle - fov_above_center, 0.01, PI - 0.01).sin();
-        /*let point = this.point;
-        let x = point.x;
-        let y = point.y;*/
 
         // Calculate z distance of the farthest fragment that should be rendered.
         let furthest_distance =
-            (PI / 2.0 - _pitch).cos() * top_half_surface_distance + camera_to_center_distance;
+            (PI / 2.0 - pitch).cos() * top_half_surface_distance + camera_to_center_distance;
         // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthest_distance`
         let far_z = furthest_distance * 1.01;
 
-        // The larger the value of nearZ is
+        // The larger the value of near_z is
         // - the more depth precision is available for features (good)
         // - clipping starts appearing sooner when the camera is close to 3d features (bad)
         //
         // Smaller values worked well for mapbox-gl-js but deckgl was encountering precision issues
         // when rendering it's layers using custom layers. This value was experimentally chosen and
         // seems to solve z-fighting issues in deckgl while not clipping buildings too close to the camera.
-        let nearZ = height / 50.0;
+        //
+        // in tile.vertex.wgsl we are setting each layer's final `z` in ndc space to `z_index`.
+        // This means that regardless of the `znear` value all layers will be rendered as part
+        // of the near plane.
+        // These values have been selected experimentally:
+        // https://www.sjbaker.org/steve/omniv/love_your_z_buffer.html
+        let near_z = height / 50.0;
 
-        let mut perspective = cgmath::perspective(Rad(_fov), aspect, nearZ, far_z);
+        let mut perspective = cgmath::perspective(fovy, aspect, near_z, far_z);
 
-        // TODO: Does nothing?
-        //Apply center of perspective offset
-        perspective.z[0] = -offset_x * 2.0 / width;
-        perspective.z[1] = offset_y * 2.0 / height;
+        // TODO: https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L881-L883
+        // Apply center of perspective offset
+        // perspective.z[0] = -offset_x * 2.0 / width;
+        // perspective.z[1] = offset_y * 2.0 / height;
 
+        // TODO: https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L885-L889
         //perspective = perspective * Matrix4::from_nonuniform_scale(1.0, -1.0, 1.0);
         perspective = perspective
             * Matrix4::from_translation(Vector3::new(0.0, 0.0, -camera_to_center_distance));
@@ -499,25 +482,7 @@ impl Perspective {
         //mat4.rotateZ(m, m, this.angle);
         //mat4.translate(m, m, [-x, -y, 0]);
 
-        fn circumference_at_latitude(latitude: f64) -> f64 {
-            let earth_radius = 6371008.8;
-            let earth_circumfrence = 2.0 * PI * earth_radius;
-            return earth_circumfrence * (latitude * PI / 180.0).cos();
-        }
-        fn mercator_zfrom_altitude(altitude: f64, lat: f64) -> f64 {
-            return altitude / circumference_at_latitude(lat);
-        }
-
-        // TODO: Does nothing?
-        // scale vertically to meters per pixel (inverse of ground resolution):
-        let world_size = TILE_SIZE * 2_u32.pow(13) as f64;
-        let center_lat = 46.51993;
-        perspective = perspective
-            * Matrix4::from_nonuniform_scale(
-                1.0,
-                1.0,
-                mercator_zfrom_altitude(1.0, center_lat) * world_size,
-            );
+        // TODO Missing: https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L895-L902
 
         OPENGL_TO_WGPU_MATRIX * perspective
     }
@@ -542,13 +507,7 @@ mod tests {
             height as u32,
         );
         // 4732.561319582916
-        let perspective = Perspective::new(
-            width as u32,
-            height as u32,
-            cgmath::Deg(45.0),
-            0.1,
-            100000.0,
-        );
+        let perspective = Perspective::new(width as u32, height as u32, cgmath::Deg(45.0));
         let view_proj: ViewProjection = camera.calc_view_proj(&perspective);
         let inverted_view_proj: InvertedViewProjection = view_proj.invert();
 

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -184,9 +184,37 @@ impl Perspective {
         self.fovy
     }
 
-    // Adopted from https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L827-L879
     pub fn calc_matrix(&self, aspect: f64, near_z: f64, far_z: f64) -> Matrix4<f64> {
         perspective(self.fovy, aspect, near_z, far_z)
+    }
+
+    pub fn calc_matrix_with_center(
+        &self,
+        width: f64,
+        height: f64,
+        near_z: f64,
+        far_z: f64,
+        center_offset: Point2<f64>,
+    ) -> Matrix4<f64> {
+        let aspect = width / height;
+
+        // from projection.rs
+        let angle = self.fovy / 2.0;
+        let ymax = near_z * Rad::tan(angle);
+        let xmax = ymax * aspect;
+
+        // https://webglfundamentals.org/webgl/lessons/webgl-qna-how-can-i-move-the-perspective-vanishing-point-from-the-center-of-the-canvas-.html
+        let off_x = -center_offset.x * (xmax * 2.0) / width;
+        let off_y = center_offset.y * (ymax * 2.0) / height;
+
+        frustum(
+            -xmax + off_x,
+            xmax + off_x,
+            -ymax + off_y,
+            ymax + off_y,
+            near_z,
+            far_z,
+        )
     }
 }
 

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -240,7 +240,7 @@ impl Perspective {
         let ymax = near_z * half_fovy.tan();
 
         //let xmax = ymax * aspect;
-        let half_fovx = Rad(2.0 * (half_fovy.tan() * (width / height)).atan()) / 2.0;
+        let half_fovx = Rad(2.0 * (half_fovy.tan() * aspect).atan()) / 2.0;
         let xmax = near_z * half_fovx.tan();
 
         let offset_x = center_offset.x * 2.0 / width; // TODO - or + does not matter

--- a/maplibre/src/render/mod.rs
+++ b/maplibre/src/render/mod.rs
@@ -63,6 +63,7 @@ pub mod render_commands;
 pub mod render_phase;
 pub mod settings;
 pub mod tile_view_pattern;
+pub mod view_state;
 
 pub use shaders::ShaderVertex;
 

--- a/maplibre/src/render/shaders/tile.vertex.wgsl
+++ b/maplibre/src/render/shaders/tile.vertex.wgsl
@@ -36,8 +36,6 @@ fn main(
     //}
 
     var final_position = mat4x4<f32>(translate1, translate2, translate3, translate4) * vec4<f32>(position + normal * width, z, 1.0);
-    // FIXME: how to fix z-fighting?
-    final_position.z = z_index;
 
     return VertexOutput(color, final_position);
 }

--- a/maplibre/src/render/shaders/tile_debug.vertex.wgsl
+++ b/maplibre/src/render/shaders/tile_debug.vertex.wgsl
@@ -21,7 +21,7 @@ fn main(
     let target_width = 1.0;
     let target_height = 1.0;
 
-    let WIDTH = EXTENT * zoom_factor / 1024.0;
+    let WIDTH = EXTENT / 256.0 * zoom_factor; // Width is 1/256 of a tile
 
     var VERTICES: array<vec3<f32>, 24> = array<vec3<f32>, 24>(
         // Debug lines vertices
@@ -71,6 +71,6 @@ fn main(
     );
 
     var final_position = mat4x4<f32>(translate1, translate2, translate3, translate4) * vec4<f32>((scaling * vertex), 1.0);
-    final_position.z = 1.0;
+    final_position.z = 10.0;
     return VertexOutput(DEBUG_COLOR, final_position);
 }

--- a/maplibre/src/render/shaders/tile_debug.vertex.wgsl
+++ b/maplibre/src/render/shaders/tile_debug.vertex.wgsl
@@ -71,6 +71,6 @@ fn main(
     );
 
     var final_position = mat4x4<f32>(translate1, translate2, translate3, translate4) * vec4<f32>((scaling * vertex), 1.0);
-    final_position.z = 10.0;
+    final_position.z = 1.0;
     return VertexOutput(DEBUG_COLOR, final_position);
 }

--- a/maplibre/src/render/shaders/tile_raster.vertex.wgsl
+++ b/maplibre/src/render/shaders/tile_raster.vertex.wgsl
@@ -42,7 +42,7 @@ fn main(
     let tex_coords = TEX_COORDS[vertex_idx];
 
     var final_position = mat4x4<f32>(translate1, translate2, translate3, translate4) * vec4<f32>(vertex, 1.0);
-    //final_position.z = z_index;
+    final_position.z = z_index;
 
     return VertexOutput(tex_coords, final_position);
 }

--- a/maplibre/src/render/shaders/tile_raster.vertex.wgsl
+++ b/maplibre/src/render/shaders/tile_raster.vertex.wgsl
@@ -42,7 +42,6 @@ fn main(
     let tex_coords = TEX_COORDS[vertex_idx];
 
     var final_position = mat4x4<f32>(translate1, translate2, translate3, translate4) * vec4<f32>(vertex, 1.0);
-    final_position.z = z_index;
 
     return VertexOutput(tex_coords, final_position);
 }

--- a/maplibre/src/render/shaders/tile_raster.vertex.wgsl
+++ b/maplibre/src/render/shaders/tile_raster.vertex.wgsl
@@ -42,7 +42,7 @@ fn main(
     let tex_coords = TEX_COORDS[vertex_idx];
 
     var final_position = mat4x4<f32>(translate1, translate2, translate3, translate4) * vec4<f32>(vertex, 1.0);
-    final_position.z = z_index;
+    //final_position.z = z_index;
 
     return VertexOutput(tex_coords, final_position);
 }

--- a/maplibre/src/render/systems/tile_view_pattern_system.rs
+++ b/maplibre/src/render/systems/tile_view_pattern_system.rs
@@ -4,7 +4,7 @@ use crate::{
     context::MapContext,
     render::{
         eventually::{Eventually, Eventually::Initialized},
-        tile_view_pattern::{ViewTileSources, WgpuTileViewPattern},
+        tile_view_pattern::{ViewTileSources, WgpuTileViewPattern, DEFAULT_TILE_SIZE},
     },
 };
 
@@ -20,7 +20,8 @@ pub fn tile_view_pattern_system(
         &Eventually<WgpuTileViewPattern>,
         &ViewTileSources
     )>() else { return; };
-    let view_region = view_state.create_view_region();
+    let view_region =
+        view_state.create_view_region(view_state.zoom().zoom_level(DEFAULT_TILE_SIZE));
 
     if let Some(view_region) = &view_region {
         let zoom = view_state.zoom();

--- a/maplibre/src/render/tile_view_pattern/mod.rs
+++ b/maplibre/src/render/tile_view_pattern/mod.rs
@@ -15,6 +15,12 @@ use crate::{
 
 pub type WgpuTileViewPattern = TileViewPattern<wgpu::Queue, wgpu::Buffer>;
 
+/// If not otherwise specified, raster tiles usually are 512.0 by 512.0 pixel.
+/// In order to support 256.0 x 256.0 raster tiles 256.0 must be used.
+///
+/// Vector tiles always have a size of 512.0.
+pub const DEFAULT_TILE_SIZE: f64 = 512.0;
+
 /// This defines the source tile shaped from which the content for the `target` is taken.
 /// For example if the target is `(0, 0, 1)` (of [`ViewTile`]) , we might use
 /// `SourceShapes::Parent((0, 0, 0))` as source.

--- a/maplibre/src/render/tile_view_pattern/pattern.rs
+++ b/maplibre/src/render/tile_view_pattern/pattern.rs
@@ -11,7 +11,11 @@ use crate::{
     tcs::world::World,
 };
 
-pub const DEFAULT_TILE_VIEW_PATTERN_SIZE: wgpu::BufferAddress = 32 * 4;
+// FIXME: If network is very slow, this pattern size can
+// increase dramatically.
+// E.g. imagine if a pattern for zoom level 18 is drawn
+// when completely zoomed out.
+pub const DEFAULT_TILE_VIEW_PATTERN_SIZE: wgpu::BufferAddress = 512;
 pub const CHILDREN_SEARCH_DEPTH: usize = 4;
 
 #[derive(Debug)]
@@ -146,7 +150,7 @@ impl<Q: Queue<B>, B> TileViewPattern<Q, B> {
         let raw_buffer = bytemuck::cast_slice(buffer.as_slice());
         if raw_buffer.len() as wgpu::BufferAddress > self.view_tiles_buffer.inner_size {
             /* TODO: We need to avoid this case by either choosing a proper size
-            TODO: (DEFAULT_TILE_VIEW_SIZE), or resizing the buffer */
+            TODO: (DEFAULT_TILE_VIEW_PATTERN_SIZE), or resizing the buffer */
             panic!("Buffer is too small to store the tile pattern!");
         }
         queue.write_buffer(&self.view_tiles_buffer.inner, 0, raw_buffer);

--- a/maplibre/src/render/view_state.rs
+++ b/maplibre/src/render/view_state.rs
@@ -510,7 +510,7 @@ impl ViewState {
 
 #[cfg(test)]
 mod tests {
-    use cgmath::{Deg, Matrix4, Point2, Vector2, Vector4};
+    use cgmath::{Deg, Matrix4, Vector2, Vector4};
 
     use crate::{
         coords::{WorldCoords, Zoom},

--- a/maplibre/src/render/view_state.rs
+++ b/maplibre/src/render/view_state.rs
@@ -1,15 +1,20 @@
-use cgmath::num_traits::clamp;
-use cgmath::prelude::*;
-use cgmath::*;
-use std::f64::consts::{FRAC_PI_2, PI};
-use std::ops::{Deref, DerefMut};
+use std::{
+    f64::consts::{FRAC_PI_2, PI},
+    ops::{Deref, DerefMut},
+};
 
-use crate::render::camera::{EdgeInsets, InvertedViewProjection, FLIP_Y, OPENGL_TO_WGPU_MATRIX};
-use crate::util::math::{bounds_from_points, Aabb2, Aabb3, Plane};
+use cgmath::{num_traits::clamp, prelude::*, *};
+
 use crate::{
     coords::{ViewRegion, WorldCoords, Zoom, ZoomLevel},
-    render::camera::{Camera, Perspective, ViewProjection},
-    util::ChangeObserver,
+    render::camera::{
+        Camera, EdgeInsets, InvertedViewProjection, Perspective, ViewProjection, FLIP_Y,
+        OPENGL_TO_WGPU_MATRIX,
+    },
+    util::{
+        math::{bounds_from_points, Aabb2, Aabb3, Plane},
+        ChangeObserver,
+    },
     window::WindowSize,
 };
 

--- a/maplibre/src/render/view_state.rs
+++ b/maplibre/src/render/view_state.rs
@@ -105,7 +105,7 @@ impl ViewState {
         // 1 Z unit is equivalent to 1 horizontal px at the center of the map
         // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
         let ground_angle = Rad(FRAC_PI_2) + pitch;
-        let fov_above_center = fovy * (0.5/*+ offset.y / height*/); // TODO: Not sure why offset is added here: Similar to `half_fovy`
+        let fov_above_center = fovy / 2.0 + fovy * center_offset.y / height; // TODO: Not sure why offset is added here: Similar to `half_fovy`
 
         let top_half_surface_distance = fov_above_center.sin() * camera_to_center_distance
             / clamp(
@@ -142,10 +142,10 @@ impl ViewState {
             self.perspective
                 .calc_matrix_with_center(width, height, near_z, far_z, center_offset);
 
-        //let mut perspective = self.perspective.calc_matrix(aspect, near_z, far_z);
+        //let mut perspective = self.perspective.calc_matrix(width / height, near_z, far_z);
         // Apply center of perspective offset, in order to move the vanishing point
-        //perspective.z[0] = -offset.x * 2.0 / width;
-        //perspective.z[1] = offset.y * 2.0 / height;
+        //perspective.z[0] = -center_offset.x * 2.0 / width;
+        //perspective.z[1] = center_offset.y * 2.0 / height;
 
         // Apply camera and move camera away from ground
         let view_projection = perspective * self.camera.calc_matrix(camera_to_center_distance);

--- a/maplibre/src/render/view_state.rs
+++ b/maplibre/src/render/view_state.rs
@@ -553,11 +553,7 @@ mod tests {
 
         state.camera.set_pitch(Deg(30.0));
         //state.camera.set_yaw(Deg(-30.0));
-        let target = state.calc_additional_height_together(
-            state.camera_to_center_distance(),
-            fov.into(),
-            Point2::new(0.0, 0.0),
-        );
-        println!("target {:?}", target);
+
+        // TODO: verify far distance plane calculation
     }
 }

--- a/maplibre/src/render/view_state.rs
+++ b/maplibre/src/render/view_state.rs
@@ -16,7 +16,6 @@ use crate::{
 const VIEW_REGION_PADDING: i32 = 1;
 const MAX_N_TILES: usize = 128;
 
-/// Stores the camera configuration.
 pub struct ViewState {
     zoom: ChangeObserver<Zoom>,
     camera: ChangeObserver<Camera>,
@@ -24,7 +23,7 @@ pub struct ViewState {
 
     width: f64,
     height: f64,
-    pub edge_insets: EdgeInsets,
+    edge_insets: EdgeInsets,
 }
 
 impl ViewState {

--- a/maplibre/src/render/view_state.rs
+++ b/maplibre/src/render/view_state.rs
@@ -89,16 +89,40 @@ impl ViewState {
         fov: Rad<f64>,
         center_offset: Point2<f64>,
         is_y: bool,
+        angle: Rad<f64>,
     ) -> f64 {
         let height = self.height;
         let width = self.width;
-        let pitch = self.camera.get_pitch();
-        let yaw = self.camera.get_yaw();
         let half_fov = fov / 2.0;
 
         // TODO: abs() fine here?
         // TODO: Is addition the correct operation?
-        let angle = Rad(pitch.0.abs() + yaw.0.abs());
+        let angle = Rad(angle.0.abs());
+
+        // The near plane rectangle has been moved by center_offset. So we increase/decrease the fov angle proportionally
+        let offset_adjusted_half_fov_alt = Rad(if is_y {
+            let near_z = 50.0;
+            let offset = center_offset.y.abs() * 2.0 / width;
+            let ymax = near_z * half_fov.tan();
+            let top = ymax * (1.0 + offset);
+            (top / near_z).atan()
+        } else {
+            let near_z = 50.0;
+            let offset = center_offset.x.abs() * 2.0 / width;
+            let xmax = near_z * half_fov.tan();
+            let right = xmax * (1.0 + offset);
+            (right / near_z).atan()
+        }); // TODO: Not sure why offset is added here: Similar to `half_fovy`
+
+        let offset_ratio = if is_y {
+            center_offset.y.abs() * 2.0 / height
+        } else {
+            center_offset.x.abs() * 2.0 / width
+        };
+
+        let offset_adjusted_half_fov = half_fov * (1.0 + offset_ratio);
+
+        //assert_abs_diff_eq!(offset_adjusted_half_fov_alt, offset_adjusted_half_fov);
 
         // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
         // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
@@ -106,24 +130,138 @@ impl ViewState {
         // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
         let ground_angle = Rad(FRAC_PI_2) + angle;
 
-        // TODO: This offset_ratio is black magic still
-        let offset_ratio = if is_y {
-            -pitch.0.signum() * center_offset.y * 2.0 / height
-        } else {
-            yaw.0.signum() * center_offset.x * 2.0 / width
-        };
-
-        let fov_above_center = half_fov * (1.0 + offset_ratio); // TODO: Not sure why offset is added here: Similar to `half_fovy`
-
-        let top_half_surface_distance = fov_above_center.sin() * camera_to_center_distance
+        let top_half_surface_distance = offset_adjusted_half_fov.sin() * camera_to_center_distance
             / clamp(
-                Rad(PI) - ground_angle - fov_above_center,
+                Rad(PI) - ground_angle - offset_adjusted_half_fov,
                 Rad(0.01),
                 Rad(PI - 0.01),
             )
             .sin();
 
         (Rad(FRAC_PI_2) - angle).cos() * top_half_surface_distance
+    }
+
+    fn calc_additional_height_together(
+        &self,
+        camera_to_center_distance: f64,
+        fov: Rad<f64>,
+        center_offset: Point2<f64>,
+    ) -> f64 {
+        let height = self.height;
+        let width = self.width;
+        let pitch = self.camera.get_pitch();
+        let yaw = self.camera.get_yaw();
+        let half_fov = fov / 2.0;
+
+        let angle = Rad(pitch.0.abs() + yaw.0.abs());
+
+        let offset_adjusted_half_fov = Rad({
+            let near_z = 50.0;
+            let offset = center_offset.y.abs() * 2.0 / width;
+            let ymax = near_z * half_fov.tan();
+            let top = ymax * (1.0 + offset);
+            (top / near_z).atan()
+        }
+        .max({
+            let near_z = 50.0;
+            let offset = center_offset.x.abs() * 2.0 / width;
+            let xmax = near_z * half_fov.tan();
+            let right = xmax * (1.0 + offset);
+            (right / near_z).atan()
+        })); // TODO: Not sure why offset is added here: Similar to `half_fovy`
+
+        //let offset_adjusted_half_fov = half_fov;
+
+        //assert_abs_diff_eq!(offset_adjusted_half_fov_alt, offset_adjusted_half_fov);
+
+        // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
+        // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
+        // 1 Z unit is equivalent to 1 horizontal px at the center of the map
+        // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
+        let ground_angle = Rad(FRAC_PI_2) + angle;
+
+        let top_half_surface_distance = offset_adjusted_half_fov.sin() * camera_to_center_distance
+            / clamp(
+                Rad(PI) - ground_angle - offset_adjusted_half_fov,
+                Rad(0.01),
+                Rad(PI - 0.01),
+            )
+            .sin();
+
+        (Rad(FRAC_PI_2) - angle).cos() * top_half_surface_distance
+    }
+
+    pub fn camera_to_center_distance(&self) -> f64 {
+        let height = self.height;
+
+        let fovy = self.perspective.fovy();
+        let half_fovy = fovy / 2.0;
+
+        // Camera height, such that given a certain field-of-view, exactly height/2 are visible on ground.
+        let camera_to_center_distance = (height / 2.0) / (half_fovy.tan()); // TODO: Not sure why it is height here and not width
+        camera_to_center_distance
+    }
+
+    pub fn furthest_distance(
+        &self,
+        camera_to_center_distance: f64,
+        center_offset: Point2<f64>,
+    ) -> f64 {
+        let width = self.width;
+        let height = self.height;
+
+        let fovy = self.perspective.fovy();
+        let half_fovy = fovy / 2.0;
+        let fovx = Rad(2.0 * (half_fovy.tan() * (width / height)).atan());
+
+        let additional_height_pitch_y = self.calc_additional_height(
+            camera_to_center_distance,
+            fovy,
+            center_offset,
+            true,
+            self.camera.get_pitch(),
+        );
+
+        let additional_height_pitch_x = self.calc_additional_height(
+            camera_to_center_distance,
+            fovx,
+            center_offset,
+            false,
+            self.camera.get_pitch(),
+        );
+
+        let additional_height_yaw_y = self.calc_additional_height(
+            camera_to_center_distance,
+            fovy,
+            center_offset,
+            true,
+            self.camera.get_yaw(),
+        );
+
+        let additional_height_yaw_x = self.calc_additional_height(
+            camera_to_center_distance,
+            fovx,
+            center_offset,
+            false,
+            self.camera.get_yaw(),
+        );
+
+        let additional_height = self.calc_additional_height_together(
+            camera_to_center_distance,
+            Rad(fovy.0.max(fovx.0)),
+            center_offset,
+        );
+
+        // Calculate z distance of the farthest fragment that should be rendered.
+        // For pitch == 0, it is `camera_to_center_distance`. Everything further away will be clipped.
+        // For pitch > 0, we add TODO
+        let furthest_distance = camera_to_center_distance
+            //    + additional_height_yaw_y.max(additional_height_yaw_x)
+            //   + additional_height_pitch_y.max(additional_height_pitch_x)
+            //   + additional_height_pitch_y + additional_height_yaw_x;
+            + additional_height;
+
+        furthest_distance
     }
 
     /// This function matches how maplibre-gl-js implements perspective and cameras at the time
@@ -137,25 +275,10 @@ impl ViewState {
         // Offset between wanted center and usual/normal center
         let center_offset = center - Vector2::new(width, height) / 2.0;
 
-        let fovy = self.perspective.fovy();
-        let half_fovy = fovy / 2.0;
-        // Camera height, such that given a certain field-of-view, exactly height/2 are visible on ground.
-        let camera_to_center_distance = (height / 2.0) / (half_fovy.tan()); // TODO: Not sure why it is height here and not width
+        let camera_to_center_distance = self.camera_to_center_distance();
 
-        let additional_height_y =
-            self.calc_additional_height(camera_to_center_distance, fovy, center_offset, true);
-
-        let fovx = fovy * (width / height);
-        let additional_height_x =
-            self.calc_additional_height(camera_to_center_distance, fovx, center_offset, false);
-
-        // Calculate z distance of the farthest fragment that should be rendered.
-        // For pitch == 0, it is `camera_to_center_distance`. Everything further away will be clipped.
-        // For pitch > 0, we add TODO
-        let furthest_distance =
-            camera_to_center_distance + additional_height_y.max(additional_height_x);
         // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthest_distance`
-        let far_z = furthest_distance * 1.01;
+        let far_z = self.furthest_distance(camera_to_center_distance, center_offset) * 1.00;
 
         // The larger the value of near_z is
         // - the more depth precision is available for features (good)
@@ -192,7 +315,14 @@ impl ViewState {
         // TODO glCoordMatrix https://github.com/maplibre/maplibre-gl-js/blob/e78ad7944ef768e67416daa4af86b0464bd0f617/src/geo/transform.ts#L754-L758
         // TODO pixelMatrix, pixelMatrixInverse https://github.com/maplibre/maplibre-gl-js/blob/e78ad7944ef768e67416daa4af86b0464bd0f617/src/geo/transform.ts#L760-L761
 
-        ViewProjection(FLIP_Y * OPENGL_TO_WGPU_MATRIX * view_projection)
+        let projection = ViewProjection(FLIP_Y * OPENGL_TO_WGPU_MATRIX * view_projection);
+        let bottom_left = self
+            .window_to_world_at_ground(&Vector2::new(0.0, 0.0), &projection.invert(), true)
+            .unwrap();
+        let x = projection.project(Vector4::new(bottom_left.x, bottom_left.y, 0.0, 1.0));
+        let ndc1 = self.clip_to_window(&x);
+        println!("{:?}", ndc1);
+        projection
     }
 
     pub fn zoom(&self) -> Zoom {
@@ -205,7 +335,7 @@ impl ViewState {
 
     pub fn update_zoom(&mut self, new_zoom: Zoom) {
         *self.zoom = new_zoom;
-        log::info!("zoom: {}", new_zoom);
+        log::info!("zoom: {new_zoom}");
     }
 
     pub fn camera(&self) -> &Camera {
@@ -249,7 +379,7 @@ impl ViewState {
     /// Adopted from [here](https://docs.microsoft.com/en-us/windows/win32/dxtecharts/the-direct3d-transformation-pipeline) (Direct3D).
     fn clip_to_window(&self, clip: &Vector4<f64>) -> Vector4<f64> {
         #[rustfmt::skip]
-            let ndc = Vector4::new(
+        let ndc = Vector4::new(
             clip.x / clip.w,
             clip.y / clip.w,
             clip.z / clip.w,
@@ -356,7 +486,7 @@ impl ViewState {
         // for z = 0 in world coordinates
         // Idea comes from: https://dondi.lmu.build/share/cg/unproject-explained.pdf
         let u = -near_world.z / (far_world.z - near_world.z);
-        if !bound || (0.0..=1.0).contains(&u) {
+        if !bound || (0.0..=1.01).contains(&u) {
             let result = near_world + u * (far_world - near_world);
             Some(Vector2::new(result.x, result.y))
         } else {
@@ -451,5 +581,59 @@ impl ViewState {
             Point2::new(min_x, min_y),
             Point2::new(max_x, max_y),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Deg, Matrix4, Point2, Vector2, Vector4};
+
+    use crate::{
+        coords::{WorldCoords, Zoom},
+        render::view_state::ViewState,
+        window::WindowSize,
+    };
+
+    #[test]
+    fn conform_transformation() {
+        let fov = Deg(60.0);
+        let mut state = ViewState::new(
+            WindowSize::new(800, 600).unwrap(),
+            WorldCoords::at_ground(0.0, 0.0),
+            Zoom::new(10.0),
+            Deg(0.0),
+            fov,
+        );
+
+        //state.furthest_distance(state.camera_to_center_distance(), Point2::new(0.0, 0.0));
+
+        let projection = state.view_projection().invert();
+
+        let bottom_left = state
+            .window_to_world_at_ground(&Vector2::new(0.0, 0.0), &projection, true)
+            .unwrap();
+        println!("bottom left on ground {:?}", bottom_left);
+        let top_right = state
+            .window_to_world_at_ground(&Vector2::new(state.width, state.height), &projection, true)
+            .unwrap();
+        println!("top right on ground {:?}", top_right);
+
+        let mut rotated = Matrix4::from_angle_x(Deg(-30.0))
+            * Vector4::new(bottom_left.x, bottom_left.y, 0.0, 0.0);
+
+        println!("bottom left rotated around x axis {:?}", rotated);
+
+        rotated = Matrix4::from_angle_y(Deg(-30.0)) * rotated;
+
+        println!("bottom left rotated around x and y axis {:?}", rotated);
+
+        state.camera.set_pitch(Deg(30.0));
+        //state.camera.set_yaw(Deg(-30.0));
+        let target = state.calc_additional_height_together(
+            state.camera_to_center_distance(),
+            fov.into(),
+            Point2::new(0.0, 0.0),
+        );
+        println!("target {:?}", target);
     }
 }

--- a/maplibre/src/render/view_state.rs
+++ b/maplibre/src/render/view_state.rs
@@ -93,17 +93,15 @@ impl ViewState {
         let fovy = self.perspective.fovy();
         let half_fov = fovy / 2.0;
         // Camera height, such that given a certain field-of-view, exactly height/2 are visible on ground.
-        let camera_to_center_distance = 0.5 / half_fov.tan() * height;
+        let camera_to_center_distance = 0.5 / half_fov.tan() * height; // TODO: Not sure why it is height here and not width
 
         // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
         // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
         // 1 Z unit is equivalent to 1 horizontal px at the center of the map
         // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
         let ground_angle = Rad(FRAC_PI_2) + pitch;
-        let fov_above_center = fovy * (0.5 + offset.y / height); // Similar to `half_fovy`, includes `offset`
+        let fov_above_center = fovy * (0.5/*+ offset.y / height*/); // TODO: Not sure why offset is added here: Similar to `half_fovy`
 
-        // fov_above_center.sin() = camera_to_center_distance / flap
-        // law of sines: camera_to_center_distance(b) * sin(fov_above_center(alpha)) / sin(beta) = top_half_surface_distance
         let top_half_surface_distance = fov_above_center.sin() * camera_to_center_distance
             / clamp(
                 Rad(PI) - ground_angle - fov_above_center,
@@ -128,7 +126,7 @@ impl ViewState {
         // when rendering it's layers using custom layers. This value was experimentally chosen and
         // seems to solve z-fighting issues in deckgl while not clipping buildings too close to the camera.
         //
-        // In tile.vertex.wgsl we are setting each layer's final `z` in ndc space to `z_index`.
+        // TODO remove: In tile.vertex.wgsl we are setting each layer's final `z` in ndc space to `z_index`.
         // This means that regardless of the `znear` value all layers will be rendered as part
         // of the near plane.
         // These values have been selected experimentally:

--- a/maplibre/src/vector/request_system.rs
+++ b/maplibre/src/vector/request_system.rs
@@ -10,6 +10,7 @@ use crate::{
         source_type::{SourceType, TessellateSource},
     },
     kernel::Kernel,
+    render::tile_view_pattern::DEFAULT_TILE_SIZE,
     style::layer::LayerPaint,
     tcs::system::System,
     vector::{
@@ -48,7 +49,8 @@ impl<E: Environment, T: VectorTransferables> System for RequestSystem<E, T> {
         }: &mut MapContext,
     ) {
         let _tiles = &mut world.tiles;
-        let view_region = view_state.create_view_region();
+        let view_region =
+            view_state.create_view_region(view_state.zoom().zoom_level(DEFAULT_TILE_SIZE));
 
         if view_state.did_camera_change() || view_state.did_zoom_change() {
             if let Some(view_region) = &view_region {

--- a/maplibre/src/vector/upload_system.rs
+++ b/maplibre/src/vector/upload_system.rs
@@ -8,6 +8,7 @@ use crate::{
     render::{
         eventually::{Eventually, Eventually::Initialized},
         shaders::{ShaderFeatureStyle, ShaderLayerMetadata, Vec4f32},
+        tile_view_pattern::DEFAULT_TILE_SIZE,
         Renderer,
     },
     style::Style,
@@ -32,7 +33,8 @@ pub fn upload_system(
         &mut Eventually<VectorBufferPool>,
     >() else { return; };
 
-    let view_region = view_state.create_view_region();
+    let view_region =
+        view_state.create_view_region(view_state.zoom().zoom_level(DEFAULT_TILE_SIZE));
 
     if let Some(view_region) = &view_region {
         upload_tesselated_layer(

--- a/maplibre/src/view_state.rs
+++ b/maplibre/src/view_state.rs
@@ -1,9 +1,13 @@
+use cgmath::num_traits::clamp;
+use cgmath::prelude::*;
+use cgmath::*;
+use std::f64::consts::PI;
 use std::ops::{Deref, DerefMut};
 
-use cgmath::Angle;
-
+use crate::render::camera::{EdgeInsets, InvertedViewProjection, FLIP_Y, OPENGL_TO_WGPU_MATRIX};
+use crate::util::math::{bounds_from_points, Aabb2, Aabb3, Plane};
 use crate::{
-    coords::{ViewRegion, WorldCoords, Zoom, ZoomLevel, TILE_SIZE},
+    coords::{ViewRegion, WorldCoords, Zoom, ZoomLevel},
     render::camera::{Camera, Perspective, ViewProjection},
     util::ChangeObserver,
     window::WindowSize,
@@ -17,49 +21,46 @@ pub struct ViewState {
     zoom: ChangeObserver<Zoom>,
     camera: ChangeObserver<Camera>,
     perspective: Perspective,
+
+    width: f64,
+    height: f64,
+    pub edge_insets: EdgeInsets,
 }
 
 impl ViewState {
-    pub fn new<F: Into<cgmath::Rad<f64>>, P: Into<cgmath::Deg<f64>>>(
+    pub fn new<F: Into<Rad<f64>>, P: Into<Deg<f64>>>(
         window_size: WindowSize,
         position: WorldCoords,
         zoom: Zoom,
         pitch: P,
         fovy: F,
     ) -> Self {
-        let tile_center = TILE_SIZE / 2.0;
-        let fovy = fovy.into();
-        let height = tile_center / (fovy / 2.0).tan();
+        let camera = Camera::new((position.x, position.y, 0.0), Deg(-90.0), pitch.into());
 
-        let camera = Camera::new(
-            (position.x, position.y, 0.0),
-            cgmath::Deg(-90.0),
-            pitch.into(),
-            window_size.width(),
-            window_size.height(),
-        );
-
-        let perspective = Perspective::new(
-            window_size.width(),
-            window_size.height(),
-            cgmath::Rad(0.6435011087932844),
-        );
+        let perspective = Perspective::new(fovy);
 
         Self {
             zoom: ChangeObserver::new(zoom),
             camera: ChangeObserver::new(camera),
             perspective,
+            width: window_size.width() as f64,
+            height: window_size.height() as f64,
+            edge_insets: EdgeInsets {
+                top: 0.0,
+                bottom: 0.0,
+                left: 0.0,
+                right: 0.0,
+            },
         }
     }
 
     pub fn resize(&mut self, width: u32, height: u32) {
-        self.perspective.resize(width, height);
-        self.camera.resize(width, height);
+        self.width = width as f64;
+        self.height = height as f64;
     }
 
     pub fn create_view_region(&self, visible_level: ZoomLevel) -> Option<ViewRegion> {
-        self.camera
-            .view_region_bounding_box(&self.view_projection().invert())
+        self.view_region_bounding_box(&self.view_projection().invert())
             .map(|bounding_box| {
                 ViewRegion::new(
                     bounding_box,
@@ -70,9 +71,101 @@ impl ViewState {
                 )
             })
     }
-
+    #[tracing::instrument(skip_all)]
     pub fn view_projection(&self) -> ViewProjection {
-        self.camera.calc_view_proj(&self.perspective)
+        let width = self.width;
+        let height = self.height;
+        let aspect = width / height;
+        let pitch = self.camera.pitch();
+
+        let center = self.edge_insets.center(width, height);
+        let offset = center - Vector2::new(width, height) / 2.0;
+
+        let fovy = self.perspective.fovy();
+        let half_fov = fovy / 2.0;
+        let camera_to_center_distance = 0.5 / half_fov.tan() * height;
+
+        // FIXME let center: LatLon = 0.0;
+        // FIXME let pixel_per_meter = center.mercatorZfromAltitude(1) * this.worldSize;
+
+        // TODO: labelPlaneMatrix https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L833-L836
+        // TODO: glCoordMatrix https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L838-L842
+        // TODO: cameraToSeaLevelDistance https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L844-L847
+        let lowest_plane = camera_to_center_distance; // TODO
+
+        // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
+        // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
+        // 1 Z unit is equivalent to 1 horizontal px at the center of the map
+        // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
+        let ground_angle = Rad(PI / 2.0) + pitch;
+        let fov_above_center = fovy * (0.5 + offset.y / height);
+        let top_half_surface_distance = fov_above_center.sin() * camera_to_center_distance
+            / clamp(
+                Rad(PI) - ground_angle - fov_above_center,
+                Rad(0.01),
+                Rad(PI - 0.01),
+            )
+            .sin();
+
+        let horizon =
+            (Rad(PI / 2.0) - self.camera.pitch()).tan() * camera_to_center_distance * 0.85;
+        let horizon_angle = Rad((horizon / camera_to_center_distance).atan());
+        let fov_center_to_horizon = horizon_angle * 2.0 * (0.5 + offset.y / (horizon * 2.0));
+        let top_half_surface_distance_horizon = (fov_center_to_horizon).sin() * lowest_plane
+            / (clamp(
+                Rad(PI) - ground_angle - fov_center_to_horizon,
+                Rad(0.01),
+                Rad(PI - 0.01),
+            ))
+            .sin();
+
+        // Calculate z distance of the farthest fragment that should be rendered.
+        // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthest_distance`
+        let top_half_min_distance =
+            top_half_surface_distance.min(top_half_surface_distance_horizon);
+        let far_z = ((Rad(PI / 2.0) - pitch).cos() * top_half_min_distance + lowest_plane) * 1.01;
+
+        // The larger the value of near_z is
+        // - the more depth precision is available for features (good)
+        // - clipping starts appearing sooner when the camera is close to 3d features (bad)
+        //
+        // Smaller values worked well for mapbox-gl-js but deckgl was encountering precision issues
+        // when rendering it's layers using custom layers. This value was experimentally chosen and
+        // seems to solve z-fighting issues in deckgl while not clipping buildings too close to the camera.
+        //
+        // in tile.vertex.wgsl we are setting each layer's final `z` in ndc space to `z_index`.
+        // This means that regardless of the `znear` value all layers will be rendered as part
+        // of the near plane.
+        // These values have been selected experimentally:
+        // https://www.sjbaker.org/steve/omniv/love_your_z_buffer.html
+        let near_z = height / 50.0;
+
+        let mut perspective = self.perspective.calc_matrix(aspect, near_z, far_z);
+
+        // Apply center of perspective offset
+        perspective.z[0] = -offset.x * 2.0 / width;
+        perspective.z[1] = offset.y * 2.0 / height;
+
+        // Move camera away from ground
+        let view_projection = perspective
+            * Matrix4::from_translation(Vector3::new(0.0, 0.0, -camera_to_center_distance))
+            // Apply camera
+            * self.camera.calc_matrix();
+
+        // TODO for the below TODOs, check GitHub blame to get an idea of what these matrices are used for!
+
+        // TODO mercatorMatrix https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L891-L893
+
+        // scale vertically to meters per pixel (inverse of ground resolution):
+        // TODO (probably only relevant for 3D terrain) mat4.scale(view_projection, view_projection, [1, 1, this._pixelPerMeter]);
+
+        // TODO pixelMatrix https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L898-L899
+        // TODO invProjMatrix, projMatrix https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L901-L904
+        // TODO (probably only relevant for 3D terrain) pixelMatrix3D https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L906-L907
+        // TODO alignedProjMatrix https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L909-L921
+        // TODO pixelMatrixInverse https://github.com/maplibre/maplibre-gl-js/blob/80e232a64716779bfff841dbc18fddc1f51535ad/src/geo/transform.ts#L923-L926
+
+        ViewProjection(FLIP_Y * OPENGL_TO_WGPU_MATRIX * view_projection)
     }
 
     pub fn zoom(&self) -> Zoom {
@@ -103,5 +196,232 @@ impl ViewState {
     pub fn update_references(&mut self) {
         self.camera.update_reference();
         self.zoom.update_reference();
+    }
+
+    /// A transform which can be used to transform between clip and window space.
+    /// Adopted from [here](https://docs.microsoft.com/en-us/windows/win32/direct3d9/viewports-and-clipping#viewport-rectangle) (Direct3D).
+    fn clip_to_window_transform(&self) -> Matrix4<f64> {
+        let min_depth = 0.0;
+        let max_depth = 1.0;
+        let x = 0.0;
+        let y = 0.0;
+        let ox = x + self.width / 2.0;
+        let oy = y + self.height / 2.0;
+        let oz = min_depth;
+        let pz = max_depth - min_depth;
+        Matrix4::from_cols(
+            Vector4::new(self.width / 2.0, 0.0, 0.0, 0.0),
+            Vector4::new(0.0, -self.height / 2.0, 0.0, 0.0),
+            Vector4::new(0.0, 0.0, pz, 0.0),
+            Vector4::new(ox, oy, oz, 1.0),
+        )
+    }
+
+    /// Transforms coordinates in clip space to window coordinates.
+    ///
+    /// Adopted from [here](https://docs.microsoft.com/en-us/windows/win32/dxtecharts/the-direct3d-transformation-pipeline) (Direct3D).
+    fn clip_to_window(&self, clip: &Vector4<f64>) -> Vector4<f64> {
+        #[rustfmt::skip]
+            let ndc = Vector4::new(
+            clip.x / clip.w,
+            clip.y / clip.w,
+            clip.z / clip.w,
+            1.0
+        );
+
+        self.clip_to_window_transform() * ndc
+    }
+    /// Alternative implementation to `clip_to_window`. Transforms coordinates in clip space to
+    /// window coordinates.
+    ///
+    /// Adopted from [here](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkViewport.html)
+    /// and [here](https://matthewwellings.com/blog/the-new-vulkan-coordinate-system/) (Vulkan).
+    fn clip_to_window_vulkan(&self, clip: &Vector4<f64>) -> Vector3<f64> {
+        #[rustfmt::skip]
+            let ndc = Vector4::new(
+            clip.x / clip.w,
+            clip.y / clip.w,
+            clip.z / clip.w,
+            1.0
+        );
+
+        let min_depth = 0.0;
+        let max_depth = 1.0;
+
+        let x = 0.0;
+        let y = 0.0;
+        let ox = x + self.width / 2.0;
+        let oy = y + self.height / 2.0;
+        let oz = min_depth;
+        let px = self.width;
+        let py = self.height;
+        let pz = max_depth - min_depth;
+        let xd = ndc.x;
+        let yd = ndc.y;
+        let zd = ndc.z;
+        Vector3::new(px / 2.0 * xd + ox, py / 2.0 * yd + oy, pz * zd + oz)
+    }
+
+    /// Order of transformations reversed: https://computergraphics.stackexchange.com/questions/6087/screen-space-coordinates-to-eye-space-conversion/6093
+    /// `w` is lost.
+    ///
+    /// OpenGL explanation: https://www.khronos.org/opengl/wiki/Compute_eye_space_from_window_space#From_window_to_ndc
+    fn window_to_world(
+        &self,
+        window: &Vector3<f64>,
+        inverted_view_proj: &InvertedViewProjection,
+    ) -> Vector3<f64> {
+        #[rustfmt::skip]
+            let fixed_window = Vector4::new(
+            window.x,
+            window.y,
+            window.z,
+            1.0
+        );
+
+        let ndc = self.clip_to_window_transform().invert().unwrap() * fixed_window;
+        let unprojected = inverted_view_proj.project(ndc);
+
+        Vector3::new(
+            unprojected.x / unprojected.w,
+            unprojected.y / unprojected.w,
+            unprojected.z / unprojected.w,
+        )
+    }
+
+    /// Alternative implementation to `window_to_world`
+    ///
+    /// Adopted from [here](https://docs.rs/nalgebra-glm/latest/src/nalgebra_glm/ext/matrix_projection.rs.html#164-181).
+    fn window_to_world_nalgebra(
+        window: &Vector3<f64>,
+        inverted_view_proj: &InvertedViewProjection,
+        width: f64,
+        height: f64,
+    ) -> Vector3<f64> {
+        let pt = Vector4::new(
+            2.0 * (window.x - 0.0) / width - 1.0,
+            2.0 * (height - window.y - 0.0) / height - 1.0,
+            window.z,
+            1.0,
+        );
+        let unprojected = inverted_view_proj.project(pt);
+
+        Vector3::new(
+            unprojected.x / unprojected.w,
+            unprojected.y / unprojected.w,
+            unprojected.z / unprojected.w,
+        )
+    }
+
+    /// Gets the world coordinates for the specified `window` coordinates on the `z=0` plane.
+    pub fn window_to_world_at_ground(
+        &self,
+        window: &Vector2<f64>,
+        inverted_view_proj: &InvertedViewProjection,
+        bound: bool,
+    ) -> Option<Vector3<f64>> {
+        let near_world =
+            self.window_to_world(&Vector3::new(window.x, window.y, 0.0), inverted_view_proj);
+
+        let far_world =
+            self.window_to_world(&Vector3::new(window.x, window.y, 1.0), inverted_view_proj);
+
+        // for z = 0 in world coordinates
+        // Idea comes from: https://dondi.lmu.build/share/cg/unproject-explained.pdf
+        let u = -near_world.z / (far_world.z - near_world.z);
+        if !bound || (0.0..=1.0).contains(&u) {
+            Some(near_world + u * (far_world - near_world))
+        } else {
+            None
+        }
+    }
+
+    /// Calculates an [`Aabb2`] bounding box which contains at least the visible area on the `z=0`
+    /// plane. One can think of it as being the bounding box of the geometry which forms the
+    /// intersection between the viewing frustum and the `z=0` plane.
+    ///
+    /// This implementation works in the world 3D space. It casts rays from the corners of the
+    /// window to calculate intersections points with the `z=0` plane. Then a bounding box is
+    /// calculated.
+    ///
+    /// *Note:* It is possible that no such bounding box exists. This is the case if the `z=0` plane
+    /// is not in view.
+    pub fn view_region_bounding_box(
+        &self,
+        inverted_view_proj: &InvertedViewProjection,
+    ) -> Option<Aabb2<f64>> {
+        let screen_bounding_box = [
+            Vector2::new(0.0, 0.0),
+            Vector2::new(self.width, 0.0),
+            Vector2::new(self.width, self.height),
+            Vector2::new(0.0, self.height),
+        ]
+        .map(|point| self.window_to_world_at_ground(&point, inverted_view_proj, false));
+
+        let (min, max) = bounds_from_points(
+            screen_bounding_box
+                .into_iter()
+                .flatten()
+                .map(|point| [point.x, point.y]),
+        )?;
+
+        Some(Aabb2::new(Point2::from(min), Point2::from(max)))
+    }
+    /// An alternative implementation for `view_bounding_box`.
+    ///
+    /// This implementation works in the NDC space. We are creating a plane in the world 3D space.
+    /// Then we are transforming it to the NDC space. In NDC space it is easy to calculate
+    /// the intersection points between an Aabb3 and a plane. The resulting Aabb2 is returned.
+    pub fn view_region_bounding_box_ndc(&self) -> Option<Aabb2<f64>> {
+        let view_proj = self.view_projection();
+        let a = view_proj.project(Vector4::new(0.0, 0.0, 0.0, 1.0));
+        let b = view_proj.project(Vector4::new(1.0, 0.0, 0.0, 1.0));
+        let c = view_proj.project(Vector4::new(1.0, 1.0, 0.0, 1.0));
+
+        let a_ndc = self.clip_to_window(&a).truncate();
+        let b_ndc = self.clip_to_window(&b).truncate();
+        let c_ndc = self.clip_to_window(&c).truncate();
+        let to_ndc = Vector3::new(1.0 / self.width, 1.0 / self.height, 1.0);
+        let plane: Plane<f64> = Plane::from_points(
+            Point3::from_vec(a_ndc.mul_element_wise(to_ndc)),
+            Point3::from_vec(b_ndc.mul_element_wise(to_ndc)),
+            Point3::from_vec(c_ndc.mul_element_wise(to_ndc)),
+        )?;
+
+        let points = plane.intersection_points_aabb3(&Aabb3::new(
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 1.0, 1.0),
+        ));
+
+        let inverted_view_proj = view_proj.invert();
+
+        let from_ndc = Vector3::new(self.width, self.height, 1.0);
+        let vec = points
+            .iter()
+            .map(|point| {
+                self.window_to_world(&point.mul_element_wise(from_ndc), &inverted_view_proj)
+            })
+            .collect::<Vec<_>>();
+
+        let min_x = vec
+            .iter()
+            .map(|point| point.x)
+            .min_by(|a, b| a.partial_cmp(b).unwrap())?;
+        let min_y = vec
+            .iter()
+            .map(|point| point.y)
+            .min_by(|a, b| a.partial_cmp(b).unwrap())?;
+        let max_x = vec
+            .iter()
+            .map(|point| point.x)
+            .max_by(|a, b| a.partial_cmp(b).unwrap())?;
+        let max_y = vec
+            .iter()
+            .map(|point| point.y)
+            .max_by(|a, b| a.partial_cmp(b).unwrap())?;
+        Some(Aabb2::new(
+            Point2::new(min_x, min_y),
+            Point2::new(max_x, max_y),
+        ))
     }
 }

--- a/maplibre/src/view_state.rs
+++ b/maplibre/src/view_state.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 const VIEW_REGION_PADDING: i32 = 1;
+const MAX_N_TILES: usize = 128;
 
 /// Stores the camera configuration.
 pub struct ViewState {
@@ -63,7 +64,7 @@ impl ViewState {
                 ViewRegion::new(
                     bounding_box,
                     VIEW_REGION_PADDING,
-                    32,
+                    MAX_N_TILES,
                     *self.zoom,
                     visible_level,
                 )

--- a/maplibre/src/view_state.rs
+++ b/maplibre/src/view_state.rs
@@ -41,14 +41,7 @@ impl ViewState {
         let perspective = Perspective::new(
             window_size.width(),
             window_size.height(),
-            cgmath::Deg(110.0),
-            // in tile.vertex.wgsl we are setting each layer's final `z` in ndc space to `z_index`.
-            // This means that regardless of the `znear` value all layers will be rendered as part
-            // of the near plane.
-            // These values have been selected experimentally:
-            // https://www.sjbaker.org/steve/omniv/love_your_z_buffer.html
-            1024.0,
-            2048.0,
+            cgmath::Rad(0.6435011087932844),
         );
 
         Self {

--- a/maplibre/src/view_state.rs
+++ b/maplibre/src/view_state.rs
@@ -63,7 +63,7 @@ impl ViewState {
         self.camera.resize(width, height);
     }
 
-    pub fn create_view_region(&self) -> Option<ViewRegion> {
+    pub fn create_view_region(&self, visible_level: ZoomLevel) -> Option<ViewRegion> {
         self.camera
             .view_region_bounding_box(&self.view_projection().invert())
             .map(|bounding_box| {
@@ -72,17 +72,13 @@ impl ViewState {
                     VIEW_REGION_PADDING,
                     32,
                     *self.zoom,
-                    self.visible_level(),
+                    visible_level,
                 )
             })
     }
 
     pub fn view_projection(&self) -> ViewProjection {
         self.camera.calc_view_proj(&self.perspective)
-    }
-
-    pub fn visible_level(&self) -> ZoomLevel {
-        self.zoom.level()
     }
 
     pub fn zoom(&self) -> Zoom {

--- a/maplibre/src/view_state.rs
+++ b/maplibre/src/view_state.rs
@@ -31,7 +31,7 @@ impl ViewState {
         let height = tile_center / (fovy / 2.0).tan();
 
         let camera = Camera::new(
-            (position.x, position.y, height),
+            (position.x, position.y, 0.0),
             cgmath::Deg(-90.0),
             pitch.into(),
             window_size.width(),

--- a/shell.nix
+++ b/shell.nix
@@ -17,6 +17,7 @@ pkgs.mkShell {
     unstable.rustup
     unstable.just
     unstable.nodejs
+    unstable.mdbook
     unstable.wasm-bindgen-cli
     unstable.tracy
     unstable.nixpkgs-fmt # To format this file: nixpkgs-fmt *.nix


### PR DESCRIPTION
~~Implements perspective transforms like in maplibre-gl-js~~

This fundamentally reworks how the far distance plane is calculated. First I wanted to implement it like in maplibre-gl-js. Though that appraoch did not allow yaw AND pitch in both directions. It only allowed pitch in a single direction (only 90°, not the full 180°).

The new approach is dicussed here: https://gamedev.stackexchange.com/questions/207328/calculation-of-far-distance-plane-based-on-yaw-and-pitch-for-a-map-renderer

It works in all directions and should also be way faster to calculate.

This PR also fixes the amount of tiles that are whown for the current zoom. If calculates the appropriate zoom level based on the current zoom and takes into account the resolution of tiles.