### PR TITLE
Bump prost crate version to 0.11.5

### DIFF
--- a/.github/actions/install-system-dependencies/action.yml
+++ b/.github/actions/install-system-dependencies/action.yml
@@ -15,7 +15,7 @@ runs:
         sudo apt-get install -y \
           protobuf-compiler \
           libwayland-dev libxkbcommon-dev # Required for winit
-    - name: Install System Dependencies (Ubuntu)
+    - name: Install System Dependencies (macOS)
       if: runner.os == 'macOS'
       shell: bash
       run: brew install protobuf

--- a/.github/workflows/library-apple.yml
+++ b/.github/workflows/library-apple.yml
@@ -78,6 +78,8 @@ jobs:
         uses: ./.github/actions/setup
         with:
           targets: aarch64-apple-ios
+      - name: Install Dependencies
+        uses: ./.github/actions/install-system-dependencies
       - name: Build Example (iOS)
         shell: bash
         run: cd apple/xcode && xcodebuild -scheme "example (iOS)" -arch arm64 -sdk iphoneos build CODE_SIGNING_ALLOWED=NO

--- a/maplibre/Cargo.toml
+++ b/maplibre/Cargo.toml
@@ -49,7 +49,7 @@ cgmath = "0.18.0"
 geo = "0.22.1"
 geo-types = { version = "0.7.6", features = ["use-rstar_0_9"] }
 rstar = "0.9.3"
-prost = "0.10.0"
+prost = "0.11.5"
 geozero = { version = "0.9.5", default-features = false, features = ["with-mvt", "with-geo"] }
 tile-grid = "0.3.0"
 


### PR DESCRIPTION
The previous version (0.10.0) wouldn’t compile (rust 1.65, `cargo run -p maplibre-demo`, linux wayland) with the following error:

```
error[E0599]: no function or associated item named `decode` found for struct `Tile` in the current scope
  --> maplibre/src/io/tile_pipelines.rs:28:40
   |
28 |         let tile = geozero::mvt::Tile::decode(data.as_ref()).expect("failed to load tile");
   |                                        ^^^^^^ function or associated item not found in `Tile`
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
1  | use prost::message::Message;
   |

error: unused import: `prost::Message`
  --> maplibre/src/io/tile_pipelines.rs:4:5
   |
4  | use prost::Message;
   |     ^^^^^^^^^^^^^^
   |
```
