### PR TITLE
Bump criterion to 0.4.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -54,3 +54,7 @@ runs:
       uses: ./.github/actions/cargo-install
       with:
         name: just
+    - name: Install cargo-criterion
+      uses: ./.github/actions/cargo-install
+      with:
+        name: cargo-criterion

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 maplibre = { path = "../maplibre", features = ["headless", "embed-static-tiles", "thread-safe-futures"] }
 
 [dev-dependencies]
-criterion = { version = "0.3.6", features = ["async_tokio"] }
+criterion = { version = "0.4.0", features = ["async_tokio"] }
 tokio = "1.19.2"
 
 [[bench]]

--- a/justfile
+++ b/justfile
@@ -70,7 +70,7 @@ test PROJECT ARCH:
   cargo test -p {{PROJECT}} --target {{ARCH}}
 
 benchmark:
-  cargo bench -p benchmarks
+  cargo criterion -p benchmarks
 
 fmt: nightly-install-rustfmt
   export RUSTUP_TOOLCHAIN=$NIGHTLY_TOOLCHAIN && cargo fmt


### PR DESCRIPTION
For the html reports, it now requires the cargo binary cargo-criterion.

Closes #216