### PR TITLE
Update trivial dependencies

### DIFF
--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -13,10 +13,10 @@ authors.workspace = true
 [dependencies]
 maplibre = { path = "../maplibre", features = ["thread-safe-futures"] }
 maplibre-winit = { path = "../maplibre-winit", version = "0.1.0"  }
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 log = "0.4.17"
 ndk-glue = "0.7.0"  # version is required by winit
-jni = "0.19.0"
+jni = "0.20.0"
 
 [lib]
 #name = "maplibre_android" Currently not supported: https://github.com/rust-windowing/android-ndk-rs/issues/136

--- a/apple/Cargo.toml
+++ b/apple/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 maplibre = { path = "../maplibre", features = ["thread-safe-futures"] }
 maplibre-winit = { path = "../maplibre-winit", version = "0.1.0"  }
 
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 
 [lib]
 name = "maplibre_apple"

--- a/maplibre-build-tools/Cargo.toml
+++ b/maplibre-build-tools/Cargo.toml
@@ -17,6 +17,6 @@ sqlite = ["rusqlite"]
 naga = { version = "*", features = ["wgsl-in"] }
 walkdir = "2.3.2"
 log = "0.4.17"
-rusqlite = { version = "0.27.0", optional = true }
+rusqlite = { version = "0.28.0", optional = true }
 serde_json = "1.0.82"
 flate2 = "1.0.24"

--- a/maplibre-demo/Cargo.toml
+++ b/maplibre-demo/Cargo.toml
@@ -15,10 +15,10 @@ web-webgl = ["maplibre/web-webgl"]
 trace = ["maplibre/trace"]
 
 [dependencies]
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 maplibre = { path = "../maplibre", version = "0.1.0", features = ["headless", "thread-safe-futures"]  }
 maplibre-winit = { path = "../maplibre-winit", version = "0.1.0"  }
 
 tile-grid = "0.3"
 
-clap = { version = "3.2.12", features = ["derive"] }
+clap = { version = "4.1.1", features = ["derive"] }

--- a/maplibre/Cargo.toml
+++ b/maplibre/Cargo.toml
@@ -24,7 +24,7 @@ headless = ["png"]
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android", target_os = "windows"))'.dependencies]
 tokio = { version = "1.20.1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7.1", features = ["rt"] }
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "gzip"] }
 reqwest-middleware-cache = "0.1.1" # FIXME: Untrusted dependency
 reqwest-middleware = "0.1.6" # FIXME: Untrusted dependency
@@ -46,7 +46,7 @@ tracing-subscriber = { version = "0.3.15", optional = true }
 cgmath = "0.18.0"
 
 # Geo
-geo = "0.22.1"
+geo = "0.23.1"
 geo-types = { version = "0.7.6", features = ["use-rstar_0_9"] }
 rstar = "0.9.3"
 prost = "0.11.5"


### PR DESCRIPTION
Edit: I had some weird troubles updating env_logger and clap on my computer. I had to `rm -r target` and rebuild from scratch. So at first I didn’t bump those, but there actually isn’t any problem.

I did not update:
* reqwest-middleware that changed its api
* rand that doesn’t seem to work with wasm target