### PR TITLE
Simplify and move Stencil reference functions

### DIFF
--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -457,17 +457,6 @@ impl WorldTileCoords {
         })
     }
 
-    /// 2D version of [`TileViewPattern::stencil_reference_value_3d`]. This is kept for reference.
-    /// For the 2D case we do not take into account the Z value, so only 4 cases exist.
-    pub fn stencil_reference_value_2d(&self) -> u8 {
-        match (self.x % 2 == 0, self.y % 2 == 0) {
-            (true, true) => 2,
-            (true, false) => 1,
-            (false, true) => 4,
-            (false, false) => 3,
-        }
-    }
-
     /// Returns unique stencil reference values for WorldTileCoords which are 3D.
     /// Tiles from arbitrary `z` can lie next to each other, because we mix tiles from
     /// different levels based on availability.

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -456,6 +456,31 @@ impl WorldTileCoords {
             z: self.z - 1,
         })
     }
+
+    /// 2D version of [`TileViewPattern::stencil_reference_value_3d`]. This is kept for reference.
+    /// For the 2D case we do not take into account the Z value, so only 4 cases exist.
+    pub fn stencil_reference_value_2d(&self) -> u8 {
+        match (self.x % 2 == 0, self.y % 2 == 0) {
+            (true, true) => 2,
+            (true, false) => 1,
+            (false, true) => 4,
+            (false, false) => 3,
+        }
+    }
+
+    /// Returns unique stencil reference values for WorldTileCoords which are 3D.
+    /// Tiles from arbitrary `z` can lie next to each other, because we mix tiles from
+    /// different levels based on availability.
+    pub fn stencil_reference_value_3d(&self) -> u8 {
+        const CASES: u8 = 4;
+        let z = u8::from(self.z);
+        match (self.x % 2 == 0, self.y % 2 == 0) {
+            (true, true) => 0 + z * CASES,
+            (true, false) => 1 + z * CASES,
+            (false, true) => 2 + z * CASES,
+            (false, false) => 3 + z * CASES,
+        }
+    }
 }
 
 impl From<(i32, i32, ZoomLevel)> for WorldTileCoords {

--- a/maplibre/src/render/render_commands.rs
+++ b/maplibre/src/render/render_commands.rs
@@ -86,7 +86,7 @@ impl RenderCommand<TileShape> for DrawMask {
         tracing::trace!("Drawing mask {}", &source_shape.coords());
 
         // Draw mask with stencil value of e.g. parent
-        let reference = tile_view_pattern.stencil_reference_value_3d(&source_shape.coords()) as u32;
+        let reference = source_shape.coords().stencil_reference_value_3d() as u32;
 
         pass.set_stencil_reference(reference);
         pass.set_vertex_buffer(
@@ -135,7 +135,7 @@ impl RenderCommand<(IndexEntry, TileShape)> for DrawTile {
             (&state.buffer_pool, &state.tile_view_pattern) else { return RenderCommandResult::Failure; };
 
         // Uses stencil value of requested tile and the shape of the requested tile
-        let reference = tile_view_pattern.stencil_reference_value_3d(&shape.coords()) as u32;
+        let reference = shape.coords().stencil_reference_value_3d() as u32;
 
         tracing::trace!(
             "Drawing layer {:?} at {}",

--- a/maplibre/src/render/tile_view_pattern.rs
+++ b/maplibre/src/render/tile_view_pattern.rs
@@ -239,12 +239,11 @@ impl<Q: Queue<B>, B> TileViewPattern<Q, B> {
     /// 2D version of [`TileViewPattern::stencil_reference_value_3d`]. This is kept for reference.
     /// For the 2D case we do not take into account the Z value, so only 4 cases exist.
     pub fn stencil_reference_value_2d(&self, world_coords: &WorldTileCoords) -> u8 {
-        match (world_coords.x, world_coords.y) {
-            (x, y) if x % 2 == 0 && y % 2 == 0 => 2,
-            (x, y) if x % 2 == 0 && y % 2 != 0 => 1,
-            (x, y) if x % 2 != 0 && y % 2 == 0 => 4,
-            (x, y) if x % 2 != 0 && y % 2 != 0 => 3,
-            _ => unreachable!(),
+        match (world_coords.x % 2 == 0, world_coords.y % 2 == 0) {
+            (true, true) => 2,
+            (true, false) => 1,
+            (false, true) => 4,
+            (false, false) => 3,
         }
     }
 
@@ -253,12 +252,12 @@ impl<Q: Queue<B>, B> TileViewPattern<Q, B> {
     /// different levels based on availability.
     pub fn stencil_reference_value_3d(&self, world_coords: &WorldTileCoords) -> u8 {
         const CASES: u8 = 4;
-        match (world_coords.x, world_coords.y, u8::from(world_coords.z)) {
-            (x, y, z) if x % 2 == 0 && y % 2 == 0 => 0 + z * CASES,
-            (x, y, z) if x % 2 == 0 && y % 2 != 0 => 1 + z * CASES,
-            (x, y, z) if x % 2 != 0 && y % 2 == 0 => 2 + z * CASES,
-            (x, y, z) if x % 2 != 0 && y % 2 != 0 => 3 + z * CASES,
-            _ => unreachable!(),
+        let z = u8::from(world_coords.z);
+        match (world_coords.x % 2 == 0, world_coords.y % 2 == 0) {
+            (true, true) => 0 + z * CASES,
+            (true, false) => 1 + z * CASES,
+            (false, true) => 2 + z * CASES,
+            (false, false) => 3 + z * CASES,
         }
     }
 }

--- a/maplibre/src/render/tile_view_pattern.rs
+++ b/maplibre/src/render/tile_view_pattern.rs
@@ -235,29 +235,4 @@ impl<Q: Queue<B>, B> TileViewPattern<Q, B> {
         }
         queue.write_buffer(&self.buffer.inner, 0, raw_buffer);
     }
-
-    /// 2D version of [`TileViewPattern::stencil_reference_value_3d`]. This is kept for reference.
-    /// For the 2D case we do not take into account the Z value, so only 4 cases exist.
-    pub fn stencil_reference_value_2d(&self, world_coords: &WorldTileCoords) -> u8 {
-        match (world_coords.x % 2 == 0, world_coords.y % 2 == 0) {
-            (true, true) => 2,
-            (true, false) => 1,
-            (false, true) => 4,
-            (false, false) => 3,
-        }
-    }
-
-    /// Returns unique stencil reference values for WorldTileCoords which are 3D.
-    /// Tiles from arbitrary `z` can lie next to each other, because we mix tiles from
-    /// different levels based on availability.
-    pub fn stencil_reference_value_3d(&self, world_coords: &WorldTileCoords) -> u8 {
-        const CASES: u8 = 4;
-        let z = u8::from(world_coords.z);
-        match (world_coords.x % 2 == 0, world_coords.y % 2 == 0) {
-            (true, true) => 0 + z * CASES,
-            (true, false) => 1 + z * CASES,
-            (false, true) => 2 + z * CASES,
-            (false, false) => 3 + z * CASES,
-        }
-    }
 }


### PR DESCRIPTION
This pull request is more a question of style concerning `stencil_reference_value_2d` and `stencil_reference_value_3d`

The first commits changes a bit how the pattern matching is written. I believe it’s a bit more “rusty” and we have the guarantee the matching is complete.

The second commit moves those functions as a member of `WorldTileCoord` instead of `TileViewPattern`. I’m still missing the bigger picture of all those parts. The observation was that no information of `TileViewPattern` is required to do the computation, but I’ll perfectly understand that there are broader implications.