### PR TITLE
Release Alpha 0.1.0

### DIFF
--- a/maplibre-build-tools/Cargo.toml
+++ b/maplibre-build-tools/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 sqlite = ["rusqlite"]
 
 [dependencies]
-naga = { version = "*", features = ["wgsl-in"] }
+naga = { version = "0.11.0", features = ["wgsl-in"] }
 walkdir = "2.3.2"
 log = "0.4.17"
 rusqlite = { version = "0.28.0", optional = true }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -49,7 +49,7 @@ tracing-wasm = { version = "0.2.1", optional = true } # TODO: Low quality depend
 serde_json = "1.0.85"
 flatbuffers = "22.10.26"
 
-image = "*" # FIXME: Remove image, use browser capabilities
+image = "0.24.5" # FIXME: Remove image, use browser capabilities
 
 [build-dependencies]
 flatc-rust = "0.2.0"

--- a/web/lib/package.json
+++ b/web/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-rs",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "",
   "scripts": {
     "clean": "rm -rf dist && rm -rf src/wasm-pack",


### PR DESCRIPTION
TODO for the release:

* Users should be able to use their own tile servers
* Map style is static
* Release is published on crates.io (maplibre/maplibre-demo) and npm (maplibre-rs)
* No releases for iOS and Android yet