### PR TITLE
Remove unwrap from write_png

### DIFF
--- a/maplibre/src/headless/system.rs
+++ b/maplibre/src/headless/system.rs
@@ -55,10 +55,12 @@ impl System for WriteSurfaceBufferSystem {
                 let padded_buffer = buffer_slice.get_mapped_range();
 
                 if self.write_to_disk {
-                    buffered_texture.write_png(
-                        &padded_buffer,
-                        format!("frame_{}.png", current_frame).as_str(),
-                    );
+                    buffered_texture
+                        .write_png(
+                            &padded_buffer,
+                            format!("frame_{}.png", current_frame).as_str(),
+                        )
+                        .expect("Could save frame to disk");
                 }
 
                 // With the current interface, we have to make sure all mapped views are

--- a/maplibre/src/render/resource/surface.rs
+++ b/maplibre/src/render/resource/surface.rs
@@ -1,8 +1,9 @@
 //! Utilities for handling surfaces which can be either headless or headed. A headed surface has
 //! a handle to a window. A headless surface renders to a texture.
 
-use log::debug;
 use std::{mem::size_of, num::NonZeroU32, sync::Arc};
+
+use log::debug;
 #[cfg(feature = "headless")]
 use thiserror::Error;
 

--- a/maplibre/src/render/resource/surface.rs
+++ b/maplibre/src/render/resource/surface.rs
@@ -4,8 +4,6 @@
 use std::{mem::size_of, num::NonZeroU32, sync::Arc};
 
 use log::debug;
-#[cfg(feature = "headless")]
-use thiserror::Error;
 
 use crate::{
     render::{eventually::HasChanged, resource::texture::TextureView, settings::RendererSettings},
@@ -83,7 +81,7 @@ pub struct BufferedTextureHead {
 }
 
 #[cfg(feature = "headless")]
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum WriteImageError {
     #[error("error while rendering to image")]
     WriteImage(#[from] png::EncodingError),


### PR DESCRIPTION
Unwraps are bad, and we should gradually remove them (#92) 

This pull request removes them from a single function to see if we agree on how to do it.

The function now returns a Result (two specific errors have been created) and there still is an `expect`. So the in case of a failure, the program will still panic.

## 🚨 Test instructions

`cargo run -p maplibre-demo  --features headless -- headless`

It write 4 png on the current path