### PR TITLE
chore: Consolidate dependency version mgmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,63 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.65"
 license = "MIT OR Apache-2.0"
-keywords = ["graphics"]
+keywords = ["graphics", "science::geo"]
 authors = ["Maximilian Ammann <max@maxammann.org>"]
+
+[workspace.dependencies]
+async-trait = "0.1.57"
+bytemuck = "1.12.1"
+bytemuck_derive = "1.2.1"
+cgmath = "0.18.0"
+cint = "0.3.1"
+clap = { version = "4.1.1", features = ["derive"] }
+console_error_panic_hook = "0.1.7"
+console_log = { version = "0.2.0", features = ["color"] }
+criterion = { version = "0.4.0", features = ["async_tokio"] }
+csscolorparser = { version = "0.6.2", features = ["serde", "cint"] }
+downcast-rs = "1.2.0"
+env_logger = "0.10.0"
+flatbuffers = "22.10.26"
+flatc-rust = "0.2.0"
+flate2 = "1.0.24"
+geo = "0.23.1"
+geo-types = { version = "0.7.6", features = ["use-rstar_0_9"] }
+geozero = { version = "0.9.8", default-features = false, features = ["with-mvt", "with-geo"] }
+image = { version = "0.24", default-features = false, features = ["jpeg", "webp", "png"] }
+include_dir = "0.7.2"
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }  # TODO: Untrusted dependency
+jni = "0.20.0"
+js-sys = "0.3.58"
+log = "0.4.17"
+lyon = { version = "1.0.0", features = [] }
+naga = { version = "*", features = ["wgsl-in"] }
+ndk-glue = "0.7.0"  # version is required by winit
+png = { version = "0.17.5" }
+rand = { version = "0.7", features = ["wasm-bindgen"] }
+raw-window-handle = "0.5.0"
+reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "gzip"] }  # Use rusttls on android because cross compiling is difficult
+reqwest-middleware = "0.1.6"  # FIXME: Untrusted dependency
+reqwest-middleware-cache = "0.1.1"  # FIXME: Untrusted dependency
+rstar = "0.9.3"
+rusqlite = { version = "0.28.0" }
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
+smallvec = "1.9.0"
+thiserror = "1.0"
+tile-grid = "0.3.0"
+tokio = "1.19.2"  # Individual features are customized in each crate
+tokio-util = { version = "0.7.1", features = ["rt"] }
+tracing = "0.1.36"
+tracing-subscriber = "0.3.15"
+tracing-tracy = "0.10"
+tracing-wasm = "0.2.1"  # TODO: Low quality dependency (remove in a separate PR!)
+walkdir = "2.3.2"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen-test = "0.3"
+web-sys = "0.3.58"  # Individual features are customized in each crate
+wgpu = "0.16.0"
+winit = { version = "0.27.2", default-features = false }
 
 [profile.release]
 lto = true

--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -13,10 +13,10 @@ authors.workspace = true
 [dependencies]
 maplibre = { path = "../maplibre", features = ["thread-safe-futures"] }
 maplibre-winit = { path = "../maplibre-winit", version = "0.1.0"  }
-env_logger = "0.10.0"
-log = "0.4.17"
-ndk-glue = "0.7.0"  # version is required by winit
-jni = "0.20.0"
+env_logger.workspace = true
+log.workspace = true
+ndk-glue.workspace = true
+jni.workspace = true
 
 [lib]
 #name = "maplibre_android" Currently not supported: https://github.com/rust-windowing/android-ndk-rs/issues/136

--- a/apple/Cargo.toml
+++ b/apple/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 maplibre = { path = "../maplibre", features = ["thread-safe-futures"] }
 maplibre-winit = { path = "../maplibre-winit", version = "0.1.0"  }
 
-env_logger = "0.10.0"
+env_logger.workspace = true
 
 [lib]
 name = "maplibre_apple"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -14,8 +14,8 @@ authors.workspace = true
 maplibre = { path = "../maplibre", features = ["headless", "embed-static-tiles", "thread-safe-futures"] }
 
 [dev-dependencies]
-criterion = { version = "0.4.0", features = ["async_tokio"] }
-tokio = "1.19.2"
+criterion.workspace = true
+tokio.workspace = true
 
 [[bench]]
 name = "render"

--- a/maplibre-build-tools/Cargo.toml
+++ b/maplibre-build-tools/Cargo.toml
@@ -14,9 +14,9 @@ authors.workspace = true
 sqlite = ["rusqlite"]
 
 [dependencies]
-naga = { version = "*", features = ["wgsl-in"] }
-walkdir = "2.3.2"
-log = "0.4.17"
-rusqlite = { version = "0.28.0", optional = true }
-serde_json = "1.0.82"
-flate2 = "1.0.24"
+naga.workspace = true
+walkdir.workspace = true
+log.workspace = true
+rusqlite = { workspace = true, optional = true }
+serde_json.workspace = true
+flate2.workspace = true

--- a/maplibre-demo/Cargo.toml
+++ b/maplibre-demo/Cargo.toml
@@ -16,10 +16,8 @@ trace = ["maplibre/trace"]
 headless = ["maplibre/headless"]
 
 [dependencies]
-env_logger = "0.10.0"
+env_logger.workspace = true
 maplibre = { path = "../maplibre", version = "0.1.0", features = ["thread-safe-futures"]  }
 maplibre-winit = { path = "../maplibre-winit", version = "0.1.0"  }
-
-tile-grid = "0.3"
-
-clap = { version = "4.1.1", features = ["derive"] }
+tile-grid.workspace = true
+clap.workspace = true

--- a/maplibre-winit/Cargo.toml
+++ b/maplibre-winit/Cargo.toml
@@ -10,22 +10,23 @@ keywords.workspace = true
 authors.workspace = true
 
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android", target_os = "windows"))'.dependencies]
-tokio = { version = "1.19.2", features = ["rt"] }
+tokio.workspace = true
 
-[target.'cfg(target_os = "android")'.dependencies]
-winit = { version = "0.27.2", default-features = false }
+# FIXME: is this section needed?  Seems to be identical to the default
+#[target.'cfg(target_os = "android")'.dependencies]
+#winit.wokrspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-winit = { version = "0.27.2", default-features = false, features = ["x11", "wayland"] }
+winit = { workspace = true, features = ["x11", "wayland"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3.58", features = ["Window"] }
+web-sys = { workspace = true, features = ["Window"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 
 [dependencies]
 maplibre = { path = "../maplibre", version = "0.1.0" }
-winit = { version = "0.27.2", default-features = false }
-cgmath = "0.18.0"
-instant = { version = "0.1.12", features = ["wasm-bindgen"] } # TODO: Untrusted dependency
-log = "0.4.17"
+winit.workspace = true
+cgmath.workspace = true
+instant.workspace = true
+log.workspace = true

--- a/maplibre/Cargo.toml
+++ b/maplibre/Cargo.toml
@@ -24,70 +24,69 @@ raster = ["image"]
 
 
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android", target_os = "windows"))'.dependencies]
-tokio = { version = "1.20.1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
-tokio-util = { version = "0.7.1", features = ["rt"] }
-env_logger = "0.10.0"
-reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "gzip"] }
-reqwest-middleware-cache = "0.1.1" # FIXME: Untrusted dependency
-reqwest-middleware = "0.1.6" # FIXME: Untrusted dependency
-tracing-tracy = { version = "0.10", optional = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio-util.workspace = true
+env_logger.workspace = true
+reqwest.workspace = true
+reqwest-middleware-cache.workspace = true
+reqwest-middleware.workspace = true
+tracing-tracy = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-# Use rusttls on android because cross compiling is difficult
-reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "gzip"] }
+reqwest.workspace = true
 
 [dependencies]
-async-trait = "0.1.57"
-instant = { version = "0.1.12", features = ["wasm-bindgen"] } # TODO: Untrusted dependency
+async-trait.workspace = true
+instant.workspace = true
 
 # Tracing
-tracing = "0.1.36"
-tracing-subscriber = { version = "0.3.15", optional = true }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, optional = true }
 
 # Maths
-cgmath = "0.18.0"
+cgmath.workspace = true
 
 # Geo
-geo = "0.23.1"
-geo-types = { version = "0.7.6", features = ["use-rstar_0_9"] }
-rstar = "0.9.3"
-geozero = { version = "0.9.8", default-features = false, features = ["with-mvt", "with-geo"] }
-tile-grid = "0.3.0"
+geo.workspace = true
+geo-types.workspace = true
+rstar.workspace = true
+geozero.workspace = true
+tile-grid.workspace = true
 
 # Rendering
-wgpu = "0.16.0"
+wgpu.workspace = true
 #wgpu = { git = "https://github.com/gfx-rs/wgpu.git", rev = "" }
-lyon = { version = "1.0.0", features = [] }
-raw-window-handle = "0.5.0"
+lyon.workspace = true
+raw-window-handle.workspace = true
 
 # cached = "0.32"
 
 # Logging
-log = "0.4.17"
+log.workspace = true
 
 # Utils
-bytemuck = "1.12.1"
-bytemuck_derive = "1.2.1"
-thiserror = "1.0"
+bytemuck.workspace = true
+bytemuck_derive.workspace = true
+thiserror.workspace = true
 
 # Static tiles inclusion
-include_dir = "0.7.2"
+include_dir.workspace = true
 
 # JSON
-serde = { version = "1.0.144", features = ["derive"] }
-serde_json = "1.0.85"
+serde.workspace = true
+serde_json.workspace = true
 
 # Colors
-csscolorparser = { version = "0.6.2", features = ["serde", "cint"] }
-cint = "0.3.1"
+csscolorparser.workspace = true
+cint.workspace = true
 
 # Required by bevy renderer
-downcast-rs = "1.2.0"
-smallvec = "1.9.0"
+downcast-rs.workspace = true
+smallvec.workspace = true
 
 # Headless
-png = { version = "0.17.5", optional = true }
-image = { version = "0.24", default-features = false, features = ["jpeg", "webp", "png"], optional = true }
+png = { workspace = true, optional = true }
+image = { workspace = true, optional = true }
 
 [build-dependencies]
 maplibre-build-tools = { path = "../maplibre-build-tools", version = "0.1.0" }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -23,36 +23,35 @@ wasm-opt = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-trait = "0.1.56"
+async-trait.workspace = true
 maplibre = { path = "../maplibre" }
 maplibre-winit = { path = "../maplibre-winit", version = "0.1.0"  }
 
-log = "0.4.17"
-rand = { version = "0.7", features = ["wasm-bindgen"] }
+log.workspace = true
+rand.workspace = true
 
-thiserror = "1.0"
+thiserror.workspace = true
 
-console_error_panic_hook = "0.1.7"
-# Exact version requirement can be removed as soon as https://github.com/gfx-rs/wgpu/pull/2954 is merged
-web-sys = { version = "0.3.58", features = [
+console_error_panic_hook.workspace = true
+web-sys = { workspace = true, features = [
     "Window",
     "Worker", "WorkerGlobalScope", "DedicatedWorkerGlobalScope", "MessageEvent",
     "Request", "RequestInit", "RequestMode", "Response", "Headers",
     "ErrorEvent"
 ] }
-js-sys = "0.3.58"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
-console_log = { version = "0.2.0", features = ["color"] }
-tracing-wasm = { version = "0.2.1", optional = true } # TODO: Low quality dependency (remove in a separate PR!)
+js-sys.workspace = true
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
+console_log.workspace = true
+tracing-wasm = { workspace = true, optional = true } # TODO: Low quality dependency (remove in a separate PR!)
 # For passing Inputs in AsyncProcedureCalls
-serde_json = "1.0.85"
-flatbuffers = "22.10.26"
+serde_json.workspace = true
+flatbuffers.workspace = true
 
-image = "*" # FIXME: Remove image, use browser capabilities
+image.workspace = true # FIXME: Remove image, use browser capabilities
 
 [build-dependencies]
-flatc-rust = "0.2.0"
+flatc-rust.workspace = true
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test.workspace = true


### PR DESCRIPTION
Move all dependencies to workspace so that we can keep all versions across packages in one spot.

Also add a geo keyword to the packagess.

See https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table