### PR TITLE
chore: Bump consolidated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,59 +25,71 @@ keywords = ["graphics", "science::geo"]
 authors = ["Maximilian Ammann <max@maxammann.org>"]
 
 [workspace.dependencies]
-async-trait = "0.1.57"
-bytemuck = "1.12.1"
-bytemuck_derive = "1.2.1"
+#
+# These dependencies are kept back due to some issues
+#
+# TODO: Not yet upgraded because wasm-bindgen feature was later removed
+rand = { version = "0.7.3", features = ["wasm-bindgen"] }
+
+# FIXME: Untrusted dependency, 0.2.x doesn't compile with cache middleware
+reqwest-middleware = "0.1.6"
+
+# TODO: Upgrade to 0.28+ and remove ndk-glue. See https://github.com/rust-windowing/winit#android
+winit = { version = "0.27.5", default-features = false, features = [] }
+
+#
+# These dependencies should be updated to the latest version
+#
+async-trait = "0.1.68"
+bytemuck = "1.13.1"
+bytemuck_derive = "1.4.1"
 cgmath = "0.18.0"
 cint = "0.3.1"
-clap = { version = "4.1.1", features = ["derive"] }
+clap = { version = "4.3.0", features = ["derive"] }
 console_error_panic_hook = "0.1.7"
-console_log = { version = "0.2.0", features = ["color"] }
-criterion = { version = "0.4.0", features = ["async_tokio"] }
+console_log = { version = "1.0.0", features = ["color"] }
+criterion = { version = "0.5.1", features = ["async_tokio"] }
 csscolorparser = { version = "0.6.2", features = ["serde", "cint"] }
 downcast-rs = "1.2.0"
 env_logger = "0.10.0"
-flatbuffers = "22.10.26"
+flatbuffers = "23.1.21"
 flatc-rust = "0.2.0"
-flate2 = "1.0.24"
-geo = "0.23.1"
-geo-types = { version = "0.7.6", features = ["use-rstar_0_9"] }
-geozero = { version = "0.9.8", default-features = false, features = ["with-mvt", "with-geo"] }
+flate2 = "1.0.26"
+geo = "0.25.0"
+geo-types = { version = "0.7.9", features = ["use-rstar_0_9"] }
+geozero = { version = "0.9.9", default-features = false, features = ["with-mvt", "with-geo"] }
 image = { version = "0.24", default-features = false, features = ["jpeg", "webp", "png"] }
-include_dir = "0.7.2"
+include_dir = "0.7.3"
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }  # TODO: Untrusted dependency
-jni = "0.20.0"
-js-sys = "0.3.58"
-log = "0.4.17"
-lyon = { version = "1.0.0", features = [] }
-naga = { version = "*", features = ["wgsl-in"] }
-ndk-glue = "0.7.0"  # version is required by winit
-png = { version = "0.17.5" }
-rand = { version = "0.7", features = ["wasm-bindgen"] }
-raw-window-handle = "0.5.0"
-reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "gzip"] }  # Use rusttls on android because cross compiling is difficult
-reqwest-middleware = "0.1.6"  # FIXME: Untrusted dependency
+jni = "0.21.1"
+js-sys = "0.3.63"
+log = "0.4.18"
+lyon = { version = "1.0.1", features = [] }
+naga = { version = "0.12.1", features = ["wgsl-in"] }
+ndk-glue = "0.7.0"  # version is required by winit. This might for winit 0.28+, see https://github.com/rust-windowing/winit#Android
+png = { version = "0.17.8" }
+raw-window-handle = "0.5.2"
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls", "gzip"] }  # Use rusttls on android because cross compiling is difficult
 reqwest-middleware-cache = "0.1.1"  # FIXME: Untrusted dependency
-rstar = "0.9.3"
-rusqlite = { version = "0.28.0" }
-serde = { version = "1.0.144", features = ["derive"] }
-serde_json = "1.0.85"
-smallvec = "1.9.0"
-thiserror = "1.0"
-tile-grid = "0.3.0"
-tokio = "1.19.2"  # Individual features are customized in each crate
-tokio-util = { version = "0.7.1", features = ["rt"] }
-tracing = "0.1.36"
-tracing-subscriber = "0.3.15"
+rstar = "0.10.0"
+rusqlite = { version = "0.29.0" }
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = "1.0.96"
+smallvec = "1.10.0"
+thiserror = "1.0.40"
+tile-grid = "0.4"
+tokio = "1.28.2"  # Individual features are customized in each crate
+tokio-util = { version = "0.7.8", features = ["rt"] }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
 tracing-tracy = "0.10"
 tracing-wasm = "0.2.1"  # TODO: Low quality dependency (remove in a separate PR!)
-walkdir = "2.3.2"
+walkdir = "2.3.3"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 wasm-bindgen-test = "0.3"
-web-sys = "0.3.58"  # Individual features are customized in each crate
-wgpu = "0.16.0"
-winit = { version = "0.27.2", default-features = false }
+web-sys = "0.3.63"  # Individual features are customized in each crate
+wgpu = "0.16.1"
 
 [profile.release]
 lto = true

--- a/justfile
+++ b/justfile
@@ -67,7 +67,14 @@ nightly-check PROJECT ARCH FEATURES: nightly-toolchain nightly-install-clippy
 test PROJECT ARCH:
     cargo test -p {{ PROJECT }} --target {{ ARCH }}
 
+# language=bash
 benchmark:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    if ! command -v cargo-criterion &> /dev/null; then
+      echo "cargo criterion could not be found. Install it with 'cargo install cargo-criterion'"
+      exit 1
+    fi
     cargo criterion -p benchmarks
 
 fmt: nightly-install-rustfmt
@@ -180,8 +187,7 @@ xcodebuild-xcframework:
 extract-tiles:
     #!/usr/bin/env bash
     set -euxo pipefail
-    if ! command -v tilelive-copy &> /dev/null
-    then
+    if ! command -v tilelive-copy &> /dev/null; then
       echo "tilelive-copy could not be found. Install it with 'yarn global add @mapbox/tilelive @mapbox/mbtiles'"
       exit 1
     fi


### PR DESCRIPTION
Merge #281 first, before this one!!!

Bump most dependencies to the latest, except a few ones below.

### TODO in other PRs
  - [ ] The `rand` crate could not be upgraded to v0.8+ because it removed `wasm-bindgen` feature
  - [ ] Can't update `winit` crate to v0.28+ because `ndk-glue` is removed. See [notes](https://github.com/rust-windowing/winit#android)
  - [ ] Can't update `reqwest-middleware` to 0.2.x, unable to compile reqwest-middleware-cache with it