### PR TITLE
chore: Inline format args

### DIFF
--- a/maplibre-build-tools/src/mbtiles.rs
+++ b/maplibre-build-tools/src/mbtiles.rs
@@ -36,16 +36,14 @@ pub fn extract<P: AsRef<Path>, R: AsRef<Path>>(
     let input_path = input_mbtiles.as_ref().to_path_buf();
     if !input_path.is_file() {
         return Err(Error::IO(format!(
-            "Input file {:?} is not a file",
-            input_path
+            "Input file {input_path:?} is not a file",
         )));
     }
 
     let output_path = output_dir.as_ref().to_path_buf();
     if output_path.exists() {
         return Err(Error::IO(format!(
-            "Output directory {:?} already exists",
-            output_path
+            "Output directory {output_path:?} already exists"
         )));
     }
     let connection = Connection::open(input_path)?;
@@ -92,11 +90,11 @@ fn extract_tile(tile: &Row, output_path: &Path) -> Result<(), Error> {
     // Flip vertical axis
     y = flip_vertical_axis(z, y);
 
-    let tile_dir = output_path.join(format!("{}/{}", z, x));
+    let tile_dir = output_path.join(format!("{z}/{x}"));
 
     fs::create_dir_all(&tile_dir)?;
 
-    let tile_path = tile_dir.join(format!("{}.{}", y, "pbf"));
+    let tile_path = tile_dir.join(format!("{y}.pbf"));
     let tile_data = tile.get::<_, Vec<u8>>(3)?;
     let mut decoder = GzDecoder::new(tile_data.as_ref());
 

--- a/maplibre-build-tools/src/wgsl.rs
+++ b/maplibre-build-tools/src/wgsl.rs
@@ -70,7 +70,7 @@ pub fn validate_project_wgsl() {
                                 "cargo:warning={}{}",
                                 path.to_str().unwrap(),
                                 match err {
-                                    WgslError::ValidationErr(error) => format!(": {:?}", error),
+                                    WgslError::ValidationErr(error) => format!(": {error:?}"),
                                     WgslError::ParserErr { error, location } =>
                                         if let Some(SourceLocation {
                                             line_number,
@@ -78,11 +78,11 @@ pub fn validate_project_wgsl() {
                                             ..
                                         }) = location
                                         {
-                                            format!(":{}:{} {}", line_number, line_position, error)
+                                            format!(":{line_number}:{line_position} {error}")
                                         } else {
                                             error
                                         },
-                                    WgslError::IoErr(error) => format!(": {:?}", error),
+                                    WgslError::IoErr(error) => format!(": {error:?}"),
                                 }
                             );
                             exit(1);
@@ -91,7 +91,7 @@ pub fn validate_project_wgsl() {
                 }
             }
             Err(error) => {
-                println!("cargo:warning={:?}", error);
+                println!("cargo:warning={error:?}");
                 exit(1);
             }
         }

--- a/maplibre-demo/src/headless.rs
+++ b/maplibre-demo/src/headless.rs
@@ -42,7 +42,7 @@ pub async fn run_headless(tile_size: u32, min: LatLon, max: LatLon) {
 
     for (z, x, y) in GridIterator::new(10, 10, tile_limits) {
         let coords = WorldTileCoords::from((x as i32, y as i32, z.into()));
-        println!("Rendering {}", &coords);
+        println!("Rendering {coords}");
 
         let tile = map.fetch_tile(coords).await.expect("Failed to fetch!");
 

--- a/maplibre/build.rs
+++ b/maplibre/build.rs
@@ -32,7 +32,7 @@ fn embed_tiles_statically() {
 
     let root_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    let source = Path::new(&root_dir).join(format!("../test-data/munich-{}.mbtiles", MUNICH_Z));
+    let source = Path::new(&root_dir).join(format!("../test-data/munich-{MUNICH_Z}.mbtiles"));
 
     if source.exists() {
         println!("cargo:rustc-cfg=static_tiles_found");

--- a/maplibre/src/coords.rs
+++ b/maplibre/src/coords.rs
@@ -63,7 +63,7 @@ impl fmt::Debug for Quadkey {
         let ZoomLevel(level) = key[0];
         let len = level as usize;
         for part in &self.0[0..len] {
-            write!(f, "{:?}", part)?;
+            write!(f, "{part:?}")?;
         }
         Ok(())
     }
@@ -701,7 +701,7 @@ mod tests {
         let tile = WorldTileCoords::from(tile);
         let p1 = tile.transform_for_zoom(zoom) * TOP_LEFT;
         let p2 = tile.transform_for_zoom(zoom) * BOTTOM_RIGHT;
-        println!("{:?}\n{:?}", p1, p2);
+        println!("{p1:?}\n{p2:?}");
 
         assert_eq!(
             WorldCoords::from((p1.x, p1.y)).into_world_tile(zoom.level(), zoom),
@@ -775,7 +775,7 @@ mod tests {
         )
         .iter()
         {
-            println!("{}", tile_coords);
+            println!("{tile_coords}");
         }
     }
 }

--- a/maplibre/src/headless/system.rs
+++ b/maplibre/src/headless/system.rs
@@ -58,7 +58,7 @@ impl System for WriteSurfaceBufferSystem {
                     buffered_texture
                         .write_png(
                             &padded_buffer,
-                            format!("frame_{}.png", current_frame).as_str(),
+                            format!("frame_{current_frame}.png").as_str(),
                         )
                         .expect("Could save frame to disk");
                 }

--- a/maplibre/src/io/apc.rs
+++ b/maplibre/src/io/apc.rs
@@ -236,8 +236,8 @@ impl<K: OffscreenKernelEnvironment, S: Scheduler> AsyncProcedureCall<K>
         // TODO: (optimize) Using while instead of if means that we are processing all that is
         // TODO: available this might cause frame drops.
         while let Ok(message) = self.channel.1.try_recv() {
-            tracing::debug!("Data reached main thread: {:?}", &message);
-            log::debug!("Data reached main thread: {:?}", &message);
+            tracing::debug!("Data reached main thread: {message:?}");
+            log::debug!("Data reached main thread: {message:?}");
 
             if filter(&message) {
                 ret.push(message);

--- a/maplibre/src/io/static_tile_fetcher.rs
+++ b/maplibre/src/io/static_tile_fetcher.rs
@@ -24,7 +24,7 @@ pub enum StaticFetchError {
 
 impl Display for StaticFetchError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/maplibre/src/platform/noweb/mod.rs
+++ b/maplibre/src/platform/noweb/mod.rs
@@ -22,7 +22,7 @@ pub fn run_multithreaded<F: Future>(future: F) -> F::Output {
         .thread_name_fn(|| {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
             let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-            format!("maplibre-rs-pool-{}", id)
+            format!("maplibre-rs-pool-{id}")
         })
         .on_thread_start(|| {
             #[cfg(feature = "trace")]

--- a/maplibre/src/raster/request_system.rs
+++ b/maplibre/src/raster/request_system.rs
@@ -74,8 +74,8 @@ impl<E: Environment, T: RasterTransferables> System for RequestSystem<E, T> {
                         .unwrap()
                         .insert(RasterLayersDataComponent::default());
 
-                    tracing::event!(tracing::Level::ERROR, %coords, "tile request started: {}", &coords);
-                    log::info!("tile request started: {}", &coords);
+                    tracing::event!(tracing::Level::ERROR, %coords, "tile request started: {coords}");
+                    log::info!("tile request started: {coords}");
 
                     self.kernel
                         .apc()
@@ -142,7 +142,7 @@ pub fn fetch_raster_apc<
                         .map_err(|e| ProcedureError::Execution(Box::new(e)))?;
                 }
                 Err(e) => {
-                    log::error!("{:?}", &e);
+                    log::error!("{e:?}");
 
                     context
                         .send(<T as RasterTransferables>::LayerRasterMissing::build_from(

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -460,13 +460,13 @@ mod tests {
         let origin_clip_space = view_proj.project(Vector4::new(0.0, 0.0, 0.0, 1.0));
         println!("origin w in clip space: {:?}", origin_clip_space.w);
 
-        println!("world_pos: {:?}", world_pos);
-        println!("clip: {:?}", clip);
+        println!("world_pos: {world_pos:?}");
+        println!("clip: {clip:?}");
         println!("world_pos: {:?}", view_proj.invert().project(clip));
 
         println!("window: {:?}", camera.clip_to_window_vulkan(&clip));
         let window = camera.clip_to_window(&clip);
-        println!("window (matrix): {:?}", window);
+        println!("window (matrix): {window:?}");
 
         // --------- nalgebra
 
@@ -498,9 +498,9 @@ mod tests {
 
         // for z = 0 in world coordinates
         let u = -near_world.z / (far_world.z - near_world.z);
-        println!("u: {:?}", u);
+        println!("u: {u:?}");
         let unprojected = near_world + u * (far_world - near_world);
-        println!("unprojected: {:?}", unprojected);
+        println!("unprojected: {unprojected:?}");
         assert!(Vector3::new(world_pos.x, world_pos.y, world_pos.z).abs_diff_eq(&unprojected, 0.05));
 
         // ---- test for unproject
@@ -516,9 +516,9 @@ mod tests {
 
         // for z = 0 in world coordinates
         let u = -near_world.z / (far_world.z - near_world.z);
-        println!("u: {:?}", u);
+        println!("u: {u:?}");
         let unprojected = near_world + u * (far_world - near_world);
-        println!("unprojected: {:?}", unprojected);
+        println!("unprojected: {unprojected:?}");
         // ----
 
         //assert!(reverse_world.abs_diff_eq(&world_pos, 0.05))

--- a/maplibre/src/render/eventually.rs
+++ b/maplibre/src/render/eventually.rs
@@ -60,7 +60,7 @@ impl<T> Eventually<T> {
     pub fn expect_initialized_mut(&mut self, message: &str) -> &mut T {
         match self {
             Eventually::Initialized(value) => value,
-            Eventually::Uninitialized => panic!("{}", message),
+            Eventually::Uninitialized => panic!("{message}"),
         }
     }
 }

--- a/maplibre/src/render/graph/graph.rs
+++ b/maplibre/src/render/graph/graph.rs
@@ -601,10 +601,10 @@ mod tests {
         pub fn new(inputs: usize, outputs: usize) -> Self {
             TestNode {
                 inputs: (0..inputs)
-                    .map(|i| SlotInfo::new(format!("in_{}", i), SlotType::TextureView))
+                    .map(|i| SlotInfo::new(format!("in_{i}"), SlotType::TextureView))
                     .collect(),
                 outputs: (0..outputs)
-                    .map(|i| SlotInfo::new(format!("out_{}", i), SlotType::TextureView))
+                    .map(|i| SlotInfo::new(format!("out_{i}"), SlotType::TextureView))
                     .collect(),
             }
         }

--- a/maplibre/src/render/resource/surface.rs
+++ b/maplibre/src/render/resource/surface.rs
@@ -181,16 +181,16 @@ impl Surface {
         let size = window.size();
 
         let capabilities = surface.get_capabilities(adapter);
-        log::info!("adapter capabilities on surface: {:?}", capabilities);
+        log::info!("adapter capabilities on surface: {capabilities:?}");
 
         let texture_format = settings
             .texture_format
             .or_else(|| capabilities.formats.first().cloned())
             .unwrap_or(wgpu::TextureFormat::Rgba8Unorm);
-        log::info!("format description: {:?}", texture_format);
+        log::info!("format description: {texture_format:?}");
 
         let texture_format_features = adapter.get_texture_format_features(texture_format);
-        log::info!("format features: {:?}", texture_format_features);
+        log::info!("format features: {texture_format_features:?}");
 
         Self {
             size,

--- a/maplibre/src/render/resource/tracked_render_pass.rs
+++ b/maplibre/src/render/resource/tracked_render_pass.rs
@@ -21,7 +21,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Subsequent draw calls will exhibit the behavior defined by the `pipeline`.
     pub fn set_render_pipeline(&mut self, pipeline: &'a wgpu::RenderPipeline) {
-        trace!("set pipeline: {:?}", pipeline);
+        trace!("set pipeline: {pipeline:?}");
         self.pass.set_pipeline(pipeline);
     }
 
@@ -64,7 +64,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// The active vertex buffer(s) can be set with [`TrackedRenderPass::set_vertex_buffer`].
     pub fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
-        trace!("draw: {:?} {:?}", vertices, instances);
+        trace!("draw: {vertices:?} {instances:?}");
         self.pass.draw(vertices, instances);
     }
 
@@ -73,12 +73,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// The active index buffer can be set with [`TrackedRenderPass::set_index_buffer`], while the
     /// active vertex buffer(s) can be set with [`TrackedRenderPass::set_vertex_buffer`].
     pub fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
-        trace!(
-            "draw indexed: {:?} {} {:?}",
-            indices,
-            base_vertex,
-            instances
-        );
+        trace!("draw indexed: {indices:?} {base_vertex} {instances:?}");
         self.pass.draw_indexed(indices, base_vertex, instances);
     }
 
@@ -99,7 +94,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// }
     /// ```
     pub fn draw_indirect(&mut self, indirect_buffer: &'a wgpu::Buffer, indirect_offset: u64) {
-        trace!("draw indirect: {:?} {}", indirect_buffer, indirect_offset);
+        trace!("draw indirect: {indirect_buffer:?} {indirect_offset}");
         self.pass.draw_indirect(indirect_buffer, indirect_offset);
     }
 
@@ -127,11 +122,7 @@ impl<'a> TrackedRenderPass<'a> {
         indirect_buffer: &'a wgpu::Buffer,
         indirect_offset: u64,
     ) {
-        trace!(
-            "draw indexed indirect: {:?} {}",
-            indirect_buffer,
-            indirect_offset
-        );
+        trace!("draw indexed indirect: {indirect_buffer:?} {indirect_offset}");
         self.pass
             .draw_indexed_indirect(indirect_buffer, indirect_offset);
     }
@@ -140,7 +131,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Subsequent stencil tests will test against this value.
     pub fn set_stencil_reference(&mut self, reference: u32) {
-        trace!("set stencil reference: {}", reference);
+        trace!("set stencil reference: {reference}");
         self.pass.set_stencil_reference(reference);
     }
 
@@ -148,7 +139,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Subsequent draw calls will discard any fragments that fall outside this region.
     pub fn set_scissor_rect(&mut self, x: u32, y: u32, width: u32, height: u32) {
-        trace!("set_scissor_rect: {} {} {} {}", x, y, width, height);
+        trace!("set_scissor_rect: {x} {y} {width} {height}");
         self.pass.set_scissor_rect(x, y, width, height);
     }
 
@@ -157,9 +148,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// `Features::PUSH_CONSTANTS` must be enabled on the device in order to call these functions.
     pub fn set_push_constants(&mut self, stages: wgpu::ShaderStages, offset: u32, data: &[u8]) {
         trace!(
-            "set push constants: {:?} offset: {} data.len: {}",
-            stages,
-            offset,
+            "set push constants: {stages:?} offset: {offset} data.len: {}",
             data.len()
         );
         self.pass.set_push_constants(stages, offset, data);
@@ -177,15 +166,7 @@ impl<'a> TrackedRenderPass<'a> {
         min_depth: f32,
         max_depth: f32,
     ) {
-        trace!(
-            "set viewport: {} {} {} {} {} {}",
-            x,
-            y,
-            width,
-            height,
-            min_depth,
-            max_depth
-        );
+        trace!("set viewport: {x} {y} {width} {height} {min_depth} {max_depth}");
         self.pass
             .set_viewport(x, y, width, height, min_depth, max_depth);
     }
@@ -194,7 +175,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// This is a GPU debugging feature. This has no effect on the rendering itself.
     pub fn insert_debug_marker(&mut self, label: &str) {
-        trace!("insert debug marker: {}", label);
+        trace!("insert debug marker: {label}");
         self.pass.insert_debug_marker(label);
     }
 
@@ -219,7 +200,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// [`push_debug_group`]: TrackedRenderPass::push_debug_group
     /// [`pop_debug_group`]: TrackedRenderPass::pop_debug_group
     pub fn push_debug_group(&mut self, label: &str) {
-        trace!("push_debug_group marker: {}", label);
+        trace!("push_debug_group marker: {label}");
         self.pass.push_debug_group(label);
     }
 
@@ -241,7 +222,7 @@ impl<'a> TrackedRenderPass<'a> {
     }
 
     pub fn set_blend_constant(&mut self, color: wgpu::Color) {
-        trace!("set blend constant: {:?}", color);
+        trace!("set blend constant: {color:?}");
         self.pass.set_blend_constant(color);
     }
 }

--- a/maplibre/src/render/systems/graph_runner_system.rs
+++ b/maplibre/src/render/systems/graph_runner_system.rs
@@ -41,7 +41,7 @@ impl System for GraphRunnerSystem {
             {
                 let mut src: &dyn Error = &e;
                 loop {
-                    error!("> {}", src);
+                    error!("> {src}");
                     match src.source() {
                         Some(s) => src = s,
                         None => break,
@@ -51,7 +51,7 @@ impl System for GraphRunnerSystem {
 
             // TODO: Replace panic with a graceful exit in the event loop
             // if e.should_exit() { *control_flow = ControlFlow::Exit; }
-            panic!("Error running render graph: {:?}", e);
+            panic!("Error running render graph: {e:?}");
         }
 
         {

--- a/maplibre/src/schedule.rs
+++ b/maplibre/src/schedule.rs
@@ -102,7 +102,7 @@ impl Schedule {
         let label: Box<dyn StageLabel> = Box::new(label);
         self.stage_order.push(label.clone());
         let prev = self.stages.insert(label.clone(), Box::new(stage));
-        assert!(prev.is_none(), "Stage already exists: {:?}.", label);
+        assert!(prev.is_none(), "Stage already exists: {label:?}.");
         self
     }
 
@@ -138,11 +138,11 @@ impl Schedule {
             .enumerate()
             .find(|(_i, stage_label)| &***stage_label == target)
             .map(|(i, _)| i)
-            .unwrap_or_else(|| panic!("Target stage does not exist: {:?}.", target));
+            .unwrap_or_else(|| panic!("Target stage does not exist: {target:?}."));
 
         self.stage_order.insert(target_index + 1, label.clone());
         let prev = self.stages.insert(label.clone(), Box::new(stage));
-        assert!(prev.is_none(), "Stage already exists: {:?}.", label);
+        assert!(prev.is_none(), "Stage already exists: {label:?}.");
         self
     }
 
@@ -172,11 +172,11 @@ impl Schedule {
             .enumerate()
             .find(|(_i, stage_label)| &***stage_label == target)
             .map(|(i, _)| i)
-            .unwrap_or_else(|| panic!("Target stage does not exist: {:?}.", target));
+            .unwrap_or_else(|| panic!("Target stage does not exist: {target:?}."));
 
         self.stage_order.insert(target_index, label.clone());
         let prev = self.stages.insert(label.clone(), Box::new(stage));
-        assert!(prev.is_none(), "Stage already exists: {:?}.", label);
+        assert!(prev.is_none(), "Stage already exists: {label:?}.");
         self
     }
 
@@ -210,7 +210,7 @@ impl Schedule {
         func: F,
     ) -> &mut Self {
         let stage = self.get_stage_mut::<T>(&label).unwrap_or_else(move || {
-            panic!("stage '{:?}' does not exist or is the wrong type", label)
+            panic!("stage '{label:?}' does not exist or is the wrong type")
         });
         func(stage);
         self
@@ -296,10 +296,7 @@ impl Schedule {
         let stage = self
             .get_stage_mut::<SystemStage>(&stage_label)
             .unwrap_or_else(move || {
-                panic!(
-                    "Stage '{:?}' does not exist or is not a SystemStage",
-                    stage_label
-                )
+                panic!("Stage '{stage_label:?}' does not exist or is not a SystemStage")
             });
         stage.add_system(system);
         self

--- a/maplibre/src/tcs/tiles.rs
+++ b/maplibre/src/tcs/tiles.rs
@@ -88,10 +88,7 @@ impl<'w> TileSpawnResult<'w> {
         if let Some(entry) = coords.build_quad_key().map(|key| components.entry(key)) {
             match entry {
                 btree_map::Entry::Vacant(_entry) => {
-                    panic!(
-                        "Can not add a component at {}. Entity does not exist.",
-                        coords
-                    )
+                    panic!("Can not add a component at {coords}. Entity does not exist.",)
                 }
                 btree_map::Entry::Occupied(mut entry) => {
                     entry.get_mut().push(UnsafeCell::new(Box::new(component)));

--- a/maplibre/src/vector/process_vector.rs
+++ b/maplibre/src/vector/process_vector.rs
@@ -59,12 +59,7 @@ pub fn process_vector_tile<T: VectorTransferables, C: Context>(
         if let Err(e) = layer.process(&mut tessellator) {
             context.layer_missing(coords, layer_name)?;
 
-            tracing::error!(
-                "layer {} at {} tesselation failed {:?}",
-                layer_name,
-                &coords,
-                e
-            );
+            tracing::error!("layer {layer_name} at {coords} tesselation failed {e:?}");
         } else {
             context.layer_tesselation_finished(
                 coords,
@@ -87,12 +82,7 @@ pub fn process_vector_tile<T: VectorTransferables, C: Context>(
 
     for missing_layer in tile_request.layers.difference(&available_layers) {
         context.layer_missing(coords, missing_layer)?;
-
-        tracing::info!(
-            "requested layer {} at {} not found in tile",
-            missing_layer,
-            &coords
-        );
+        tracing::info!("requested layer {missing_layer} at {coords} not found in tile");
     }
 
     // Indexing
@@ -107,8 +97,7 @@ pub fn process_vector_tile<T: VectorTransferables, C: Context>(
 
     // End
 
-    tracing::info!("tile tessellated at {} finished", &coords);
-
+    tracing::info!("tile tessellated at {coords} finished");
     context.tile_finished(coords)?;
 
     Ok(())

--- a/maplibre/src/vector/render_commands.rs
+++ b/maplibre/src/vector/render_commands.rs
@@ -57,7 +57,7 @@ impl RenderCommand<LayerItem> for DrawVectorTile {
         tracing::trace!(
             "Drawing layer {:?} at {}",
             entry.style_layer.source_layer,
-            &entry.coords
+            entry.coords
         );
 
         let index_range = entry.indices_buffer_range();

--- a/maplibre/src/vector/request_system.rs
+++ b/maplibre/src/vector/request_system.rs
@@ -74,8 +74,8 @@ impl<E: Environment, T: VectorTransferables> System for RequestSystem<E, T> {
                         .unwrap()
                         .insert(VectorLayersDataComponent::default());
 
-                    tracing::event!(tracing::Level::ERROR, %coords, "tile request started: {}", &coords);
-                    log::info!("tile request started: {}", &coords);
+                    tracing::event!(tracing::Level::ERROR, %coords, "tile request started: {coords}");
+                    log::info!("tile request started: {coords}");
 
                     self.kernel
                         .apc()
@@ -150,7 +150,7 @@ pub fn fetch_vector_apc<
                     .map_err(|e| ProcedureError::Execution(Box::new(e)))?;
                 }
                 Err(e) => {
-                    log::error!("{:?}", &e);
+                    log::error!("{e:?}");
                     for to_load in &fill_layers {
                         context
                             .send(<T as VectorTransferables>::LayerMissing::build_from(

--- a/maplibre/src/vector/resource/buffer_pool.rs
+++ b/maplibre/src/vector/resource/buffer_pool.rs
@@ -507,10 +507,7 @@ impl RingIndex {
         inner_size: wgpu::BufferAddress,
     ) -> Range<wgpu::BufferAddress> {
         if new_data > inner_size {
-            panic!(
-                "can not allocate because backing buffer {:?} are too small",
-                typ
-            )
+            panic!("can not allocate because backing buffer {typ:?} are too small")
         }
 
         let mut available_gap = self.find_largest_gap(typ, inner_size);
@@ -674,7 +671,7 @@ mod tests {
             128 - 2 * 48 - 24,
             pool.available_space(BackingBufferType::Vertices)
         );
-        println!("{:?}", &pool.index);
+        println!("{:?}", pool.index);
 
         pool.allocate_layer_geometry(
             &queue,
@@ -685,7 +682,7 @@ mod tests {
             &[],
         );
         // appended now at the beginning
-        println!("{:?}", &pool.index);
+        println!("{:?}", pool.index);
         assert_eq!(24, pool.available_space(BackingBufferType::Vertices));
 
         pool.allocate_layer_geometry(
@@ -696,7 +693,7 @@ mod tests {
             2,
             &[],
         );
-        println!("{:?}", &pool.index);
+        println!("{:?}", pool.index);
         assert_eq!(0, pool.available_space(BackingBufferType::Vertices));
 
         pool.allocate_layer_geometry(
@@ -707,7 +704,7 @@ mod tests {
             2,
             &[],
         );
-        println!("{:?}", &pool.index);
+        println!("{:?}", pool.index);
         assert_eq!(24, pool.available_space(BackingBufferType::Vertices));
 
         pool.allocate_layer_geometry(
@@ -718,7 +715,7 @@ mod tests {
             2,
             &[],
         );
-        println!("{:?}", &pool.index);
+        println!("{:?}", pool.index);
         assert_eq!(0, pool.available_space(BackingBufferType::Vertices));
     }
 }

--- a/maplibre/src/vector/upload_system.rs
+++ b/maplibre/src/vector/upload_system.rs
@@ -172,7 +172,7 @@ fn upload_tesselated_layer(
                 })
                 .collect::<Vec<_>>();
 
-            log::debug!("Allocating geometry at {}", &coords);
+            log::debug!("Allocating geometry at {coords}");
             buffer_pool.allocate_layer_geometry(
                 queue,
                 *coords,

--- a/maplibre/src/view_state.rs
+++ b/maplibre/src/view_state.rs
@@ -95,7 +95,7 @@ impl ViewState {
 
     pub fn update_zoom(&mut self, new_zoom: Zoom) {
         *self.zoom = new_zoom;
-        log::info!("zoom: {}", new_zoom);
+        log::info!("zoom: {new_zoom}");
     }
 
     pub fn camera(&self) -> &Camera {

--- a/web/src/platform/singlethreaded/apc.rs
+++ b/web/src/platform/singlethreaded/apc.rs
@@ -109,8 +109,7 @@ impl Context for PassingContext {
         }
 
         log::debug!(
-            "sending message ({:?}) with {}bytes to main thread",
-            tag,
+            "sending message ({tag:?}) with {}bytes to main thread",
             data.len()
         );
 
@@ -197,7 +196,7 @@ impl<K: OffscreenKernelEnvironment> AsyncProcedureCall<K> for PassingAsyncProced
             .expect("Failed to borrow in receive of APC")
             .pop()
         {
-            log::debug!("Data reached main thread: {:?}", &message);
+            log::debug!("Data reached main thread: {message:?}");
 
             if filter(&message) {
                 ret.push(message);

--- a/web/src/platform/singlethreaded/wasm_entries.rs
+++ b/web/src/platform/singlethreaded/wasm_entries.rs
@@ -80,8 +80,7 @@ pub unsafe fn singlethreaded_main_entry(
     let tag = WebMessageTag::from_u32(tag).map_err(|e| CallError::Deserialize(Box::new(e)))?;
 
     log::debug!(
-        "received message ({:?}) with {}bytes on main thread",
-        tag,
+        "received message ({tag:?}) with {}bytes on main thread",
         buffer.byte_length()
     );
 


### PR DESCRIPTION
a few minor inlining - it seems all tracing libs can handle inlined format args properly

NOTE: there are a few references that were passed to `format!`. I don't believe this is needed - format should work just as well with the actual value.  E.g. `format!("{}", foo)` and `format!("{}", &foo)` should be the same code.  See [stackoverflow](https://stackoverflow.com/questions/30450399/does-println-borrow-or-own-the-variable/30451360#30451360) that `foo` is already being passed in as `&foo`; so `&foo` is actually `&&foo`