### PR TITLE
Disable right clicks on canvas

### DIFF
--- a/web/lib/src/canvas.ts
+++ b/web/lib/src/canvas.ts
@@ -2,5 +2,6 @@ export const preventDefaultTouchActions = () => {
     document.body.querySelectorAll("canvas").forEach(canvas => {
         canvas.addEventListener("touchstart", e => e.preventDefault())
         canvas.addEventListener("touchmove", e => e.preventDefault())
+        canvas.addEventListener("contextmenu", e => e.preventDefault())
     })
 }


### PR DESCRIPTION
This is required so we can use the right mouse to change pitch and yaw.