### PR TITLE
Update Cargo.toml to fix dependency conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ bytemuck = "1.14.0"
 bytemuck_derive = "1.5.0"
 cgmath = "0.18.0"
 cint = "0.3.1"
-clap = { version = "4.3.24", features = ["derive"] }
+clap = { version = "=4.3.24", features = ["derive"] }
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
 criterion = { version = "0.5.1", features = ["async_tokio"] }


### PR DESCRIPTION
Addresses issue: [289](https://github.com/maplibre/maplibre-rs/issues/298)

"clap" v4.5.2 does not compile with the defined toolchain and rust version. specifying exact version of dependency instead.

Tested by compiling the demo.
