### PR TITLE
Update README to mention Safari TP

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ graphics are achievable using the current stack.
 
 - [WebGL](https://webgl.demo.maplibre-rs.maplibre.org)
 - [WebGL with multithreading](https://webgl-multithreaded.demo.maplibre-rs.maplibre.org) - Does not work on Safari right now
-- [WebGPU](https://webgpu.demo.maplibre-rs.maplibre.org) - Only works with development versions of Firefox and Chrome
+- [WebGPU](https://webgpu.demo.maplibre-rs.maplibre.org) - Only works with development versions of Safari TP, Firefox and Chrome
 
 ## Current Features
 


### PR DESCRIPTION
Happy to report that it works in Safari Technology Preview now.

## 💻 Examples

<img width="857" alt="image" src="https://github.com/maplibre/maplibre-rs/assets/2332213/f18da188-9ded-4733-badd-3dbda2d5b7e7">

## 🚨 Test instructions

https://developer.apple.com/safari/technology-preview/