### PR TITLE
Add configurable text-field property for symbol layers

### DIFF
--- a/maplibre/src/sdf/tessellation_new.rs
+++ b/maplibre/src/sdf/tessellation_new.rs
@@ -42,6 +42,9 @@ type GeoResult<T> = geozero::error::Result<T>;
 pub struct TextTessellatorNew {
     geo_writer: GeoWriter,
 
+    // configuration
+    text_field: String,
+
     // output
     pub quad_buffer: VertexBuffers<ShaderSymbolVertexNew, IndexDataType>,
     pub features: Vec<Feature>,
@@ -222,10 +225,20 @@ impl TextTessellatorNew {
     }
 }
 
+impl TextTessellatorNew {
+    pub fn new(text_field: String) -> Self {
+        Self {
+            text_field,
+            ..Default::default()
+        }
+    }
+}
+
 impl Default for TextTessellatorNew {
     fn default() -> Self {
         Self {
             geo_writer: Default::default(),
+            text_field: "name".to_string(),
             quad_buffer: VertexBuffers::new(),
             features: vec![],
             collected_features: vec![],
@@ -284,8 +297,7 @@ impl PropertyProcessor for TextTessellatorNew {
         name: &str,
         value: &ColumnValue,
     ) -> geozero::error::Result<bool> {
-        // TODO: Support different tags
-        if name == "name" {
+        if name == self.text_field {
             match value {
                 ColumnValue::String(str) => {
                     self.current_text = Some(str.to_string());

--- a/maplibre/src/style/layer.rs
+++ b/maplibre/src/style/layer.rs
@@ -86,6 +86,9 @@ impl Default for RasterPaint {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SymbolPaint {
+    #[serde(rename = "text-field")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_field: Option<String>,
     // TODO a lot
 }
 

--- a/maplibre/src/style/mod.rs
+++ b/maplibre/src/style/mod.rs
@@ -151,7 +151,9 @@ impl Default for Style {
                     maxzoom: None,
                     minzoom: None,
                     metadata: None,
-                    paint: Some(LayerPaint::Symbol(SymbolPaint {})),
+                    paint: Some(LayerPaint::Symbol(SymbolPaint {
+                        text_field: Some("name".to_string()),
+                    })),
                     source: None,
                     source_layer: Some("place".to_string()),
                 },
@@ -161,7 +163,9 @@ impl Default for Style {
                     maxzoom: None,
                     minzoom: None,
                     metadata: None,
-                    paint: Some(LayerPaint::Symbol(SymbolPaint {})),
+                    paint: Some(LayerPaint::Symbol(SymbolPaint {
+                        text_field: Some("name".to_string()),
+                    })),
                     source: None,
                     source_layer: Some("transportation_name-disabled".to_string()),
                 },

--- a/maplibre/src/vector/process_vector.rs
+++ b/maplibre/src/vector/process_vector.rs
@@ -81,10 +81,13 @@ pub fn process_vector_tile<T: VectorTransferables, C: Context>(
                             )?;
                         }
                     }
-                    LayerPaint::Symbol(_) => {
-                        // TODO
+                    LayerPaint::Symbol(symbol_paint) => {
                         let mut tessellator = TextTessellator::<IndexDataType>::default();
-                        let mut tessellator_new = TextTessellatorNew::default();
+                        let text_field = symbol_paint
+                            .text_field
+                            .clone()
+                            .unwrap_or_else(|| "name".to_string());
+                        let mut tessellator_new = TextTessellatorNew::new(text_field);
 
                         if let Err(e) = layer.process(&mut tessellator_new) {
                             context.layer_missing(coords, &source_layer)?;


### PR DESCRIPTION
Add configurable `text-field` property for symbol layers, allowing style definitions to specify which feature property to use for label text (e.g. `"name"`, `"name:en"`, `"ref"`), instead of the previously hardcoded `"name"`.

## 💻 Examples

In the style definition, symbol layers can now specify `text-field`:
```json
{
  "type": "symbol",
  "paint": {
    "text-field": "name"
  }
}
```

The property flows through: StyleLayer → process_vector → TextTessellatorNew::new(text_field) → PropertyProcessor::property() which matches the configured field name when reading tile features.


## 🚨 Test instructions

Run cargo run -p maplibre-demo -- headed . Labels should render using the feature property specified by text-field in the style. Changing the value (e.g. to "name:en" or a non-existent field) should change which labels appear.

E.g. in mod.ts, if you change:

```rust
// mod.ts 148:159
                StyleLayer {
                    index: 9,
                    id: "text".to_string(),
                    maxzoom: None,
                    minzoom: None,
                    metadata: None,
                    paint: Some(LayerPaint::Symbol(SymbolPaint {
                        text_field: Some("name:en".to_string()), // <- name:en or name:da will control label language
                    })),
                    source: None,
                    source_layer: Some("place".to_string()),
                },
```



**name:da** - København

<img width="236" height="124" alt="Screenshot 2026-02-19 at 01 37 46" src="https://github.com/user-attachments/assets/8431bfeb-2533-42c6-8dae-0b39262703df" />

**name:en** - Copenhagen

<img width="343" height="194" alt="Screenshot 2026-02-19 at 01 39 20" src="https://github.com/user-attachments/assets/14acb3d5-e76a-46df-96de-1f588466e55e" />
