### PR TITLE
Fix Label Centering Alignment 

### DIFF
--- a/maplibre/src/legacy/shaping.rs
+++ b/maplibre/src/legacy/shaping.rs
@@ -304,7 +304,7 @@ fn justify_line(positioned_glyphs: &mut Vec<PositionedGlyph>, justify: f64, line
 
     let last_glyph = positioned_glyphs.last().unwrap();
     let last_advance: f64 = last_glyph.metrics.advance as f64 * last_glyph.scale;
-    let line_indent = last_glyph.x + last_advance * justify;
+    let line_indent = (last_glyph.x + last_advance) * justify;
     for positioned_glyph in positioned_glyphs {
         positioned_glyph.x -= line_indent;
         positioned_glyph.y += line_offset;


### PR DESCRIPTION
This PR fixes a bug in the text shaping engine where map labels (such as city names) were not accurately centered over their geographic anchor point.

## Examples

Before

<img width="675" height="389" alt="Screenshot 2026-02-19 at 22 44 49" src="https://github.com/user-attachments/assets/0f989473-a498-456c-b7f3-937169f72cf8" />


After

<img width="577" height="318" alt="Screenshot 2026-02-19 at 22 42 05" src="https://github.com/user-attachments/assets/20dcf437-89ee-4856-b5d6-9c3a090d16b0" />


## 🚨 Test instructions

Run the app
