### PR TITLE
fix: typos

### DIFF
--- a/docs/src/development-documents/library-packaging/web.md
+++ b/docs/src/development-documents/library-packaging/web.md
@@ -65,9 +65,9 @@ Therefore, we should stick to the `web` output format.
 ## Required Features
 
 * WASM Bundling: Make the WASM binary available to users of the maplibre-rs library
-* WebWorker Bundling: Make the WebWorker available to users of the maplibre-rs library. This could also be achived by inlining.
+* WebWorker Bundling: Make the WebWorker available to users of the maplibre-rs library. This could also be achieved by inlining.
 * WebWorker Inlining: Inline the WebWorker bundle in the library bundle as a string.
-* Predictable Paths: Without predictable paths, it's difficult for users to reference the wasm file directly from the `node_modules` directory if requried.
+* Predictable Paths: Without predictable paths, it's difficult for users to reference the wasm file directly from the `node_modules` directory if required.
 
 
 ## Bundler Feature Comparison

--- a/maplibre/src/legacy/bidi.rs
+++ b/maplibre/src/legacy/bidi.rs
@@ -15,7 +15,7 @@ pub fn apply_arabic_shaping(str: &U16String) -> U16String {
 
 // StyledText pairs each code point in a string with an integer indicating
 // the styling options to use for rendering that code point
-// The data structure is intended to accomodate the reordering/interleaving
+// The data structure is intended to accommodate the reordering/interleaving
 // of formatting that can happen when BiDi rearranges inputs
 /// maplibre/maplibre-native#4add9ea original name: StyledText
 pub type StyledText = (U16String, Vec<u8>);

--- a/maplibre/src/legacy/collision_index.rs
+++ b/maplibre/src/legacy/collision_index.rs
@@ -541,7 +541,7 @@ impl CollisionIndex {
         camera_to_anchor_distance: f64,
         pitch_with_map: bool,
     ) -> f64 {
-        // This is a quick and dirty solution for chosing which collision circles to
+        // This is a quick and dirty solution for choosing which collision circles to
         // use (since collision circles are laid out in tile units). Ideally, I
         // think we should generate collision circles on the fly in viewport
         // coordinates at the time we do collision detection.

--- a/maplibre/src/legacy/quads.rs
+++ b/maplibre/src/legacy/quads.rs
@@ -348,7 +348,7 @@ pub fn get_glyph_quads(
                 continue;
             }
 
-            // The rects have an addditional buffer that is not included in their size;
+            // The rects have an additional buffer that is not included in their size;
             let glyph_padding = 1.0;
             let mut rect_buffer = 3.0 + glyph_padding;
             let mut pixel_ratio = 1.0;

--- a/maplibre/src/legacy/shaping.rs
+++ b/maplibre/src/legacy/shaping.rs
@@ -339,14 +339,14 @@ fn get_glyph_advance(
             return 0.0;
         }
 
-        if it.expect("cant be none").is_none() {
+        if it.expect("can't be none").is_none() {
             return 0.0;
         }
 
         return (it
-            .expect("cant be none")
+            .expect("can't be none")
             .as_ref()
-            .expect("cant be none")
+            .expect("can't be none")
             .metrics
             .advance as f64
             * section.scale)
@@ -516,7 +516,7 @@ fn determine_line_breaks(
 
     let mut potential_breaks: Vec<PotentialBreak> = Vec::new();
     let mut current_x: f64 = 0.;
-    // Find first occurance of zero width space (ZWSP) character.
+    // Find first occurrence of zero width space (ZWSP) character.
     let has_server_suggested_breaks = logical_input
         .raw_text()
         .as_slice()
@@ -694,7 +694,7 @@ fn shape_lines(
                     continue;
                 }
 
-                let glyph_position_map = glyph_position_map.expect("cant be none");
+                let glyph_position_map = glyph_position_map.expect("can't be none");
 
                 let glyph_position = glyph_position_map.get(&code_point);
                 if let Some(glyph_position) = glyph_position {
@@ -705,7 +705,7 @@ fn shape_lines(
                     if glyphs.is_none() {
                         continue;
                     }
-                    let glyphs = glyphs.expect("cant be none");
+                    let glyphs = glyphs.expect("can't be none");
 
                     let glyph = glyphs.get(&code_point);
 
@@ -713,12 +713,12 @@ fn shape_lines(
                         continue;
                     }
 
-                    if glyph.expect("cant be none").is_none() {
+                    if glyph.expect("can't be none").is_none() {
                         continue;
                     }
 
                     metrics =
-                        (glyph.expect("cant be none").as_ref().expect("cant be none")).metrics;
+                        (glyph.expect("can't be none").as_ref().expect("can't be none")).metrics;
                 }
                 advance = metrics.advance as f64;
                 // We don't know the baseline, but since we're laying out

--- a/maplibre/src/legacy/shaping.rs
+++ b/maplibre/src/legacy/shaping.rs
@@ -717,8 +717,8 @@ fn shape_lines(
                         continue;
                     }
 
-                    metrics =
-                        (glyph.expect("can't be none").as_ref().expect("can't be none")).metrics;
+                    let glyphs = glyph.expect("can't be none").as_ref().expect("can't be none");
+                    metrics = glyphs.metrics;
                 }
                 advance = metrics.advance as f64;
                 // We don't know the baseline, but since we're laying out

--- a/maplibre/src/legacy/shaping.rs
+++ b/maplibre/src/legacy/shaping.rs
@@ -717,7 +717,11 @@ fn shape_lines(
                         continue;
                     }
 
-                    let glyphs = glyph.expect("can't be none").as_ref().expect("can't be none");
+                    let glyphs = glyph
+                        .expect("can't be none")
+                        .as_ref()
+                        .expect("can't be none");
+                    metrics = glyphs.metrics;
                     metrics = glyphs.metrics;
                 }
                 advance = metrics.advance as f64;

--- a/maplibre/src/raster/render_commands.rs
+++ b/maplibre/src/raster/render_commands.rs
@@ -80,7 +80,7 @@ impl RenderCommand<LayerItem> for DrawRasterTile {
             .buffer_range()
             .expect("tile_view_pattern needs to be uploaded first"); // FIXME tcs
 
-        // FIXME tcs: I passin random data here right now, but instead we need the correct metadata here
+        // FIXME tcs: I passing random data here right now, but instead we need the correct metadata here
         pass.set_vertex_buffer(
             1,
             tile_view_pattern.buffer().slice(tile_view_pattern_buffer),

--- a/maplibre/src/raster/request_system.rs
+++ b/maplibre/src/raster/request_system.rs
@@ -62,7 +62,7 @@ impl<E: Environment, T: RasterTransferables> System for RequestSystem<E, T> {
                         continue;
                     }
 
-                    // TODO: Make tesselation depend on style? So maybe we need to request even if it exists
+                    // TODO: Make tessellation depend on style? So maybe we need to request even if it exists
                     if world
                         .tiles
                         .query::<&RasterLayersDataComponent>(coords)

--- a/maplibre/src/render/camera.rs
+++ b/maplibre/src/render/camera.rs
@@ -196,7 +196,7 @@ pub struct EdgeInsets {
 
 impl EdgeInsets {
     /**
-     * Utility method that computes the new apprent center or vanishing point after applying insets.
+     * Utility method that computes the new apparent center or vanishing point after applying insets.
      * This is in pixels and with the top left being (0.0) and +y being downwards.
      *
      * @param {number} width the width

--- a/maplibre/src/render/shaders/sdf.fragment.wgsl
+++ b/maplibre/src/render/shaders/sdf.fragment.wgsl
@@ -30,7 +30,7 @@ fn main(in: VertexOutput) -> Output {
     // At which offset is the outline of the SDF?
     let outline_center_offset: f32 = -0.25;
 
-    // shift outline by `outline_width` to the ouside
+    // shift outline by `outline_width` to the outside
     let buffer_center: f32 = buffer_center_outline + outline_center_offset;
 
     let outline_color = vec3<f32>(0.0, 0.0, 0.0);

--- a/maplibre/src/render/shaders/sdf_new.fragment.wgsl
+++ b/maplibre/src/render/shaders/sdf_new.fragment.wgsl
@@ -74,7 +74,7 @@ let tex: vec2<f32> = in.v_data0.xy;
         // At which offset is the outline of the SDF?
         let outline_center_offset: f32 = -0.25;
 
-        // shift outline by `outline_width` to the ouside
+        // shift outline by `outline_width` to the outside
         let buffer_center: f32 = buffer_center_outline + outline_center_offset;
 
         let outline_color = vec3<f32>(0.0, 0.0, 0.0);

--- a/maplibre/src/render/tile_view_pattern/pattern.rs
+++ b/maplibre/src/render/tile_view_pattern/pattern.rs
@@ -61,7 +61,7 @@ impl<Q: Queue<B>, B> TileViewPattern<Q, B> {
         world: &World,
     ) -> Vec<ViewTile> {
         let mut view_tiles = Vec::with_capacity(self.view_tiles.len());
-        let mut source_tiles = HashSet::new(); // TODO: Optimization potential: Replace wit a bitmap, that allows false-negative matches
+        let mut source_tiles = HashSet::new(); // TODO: Optimization potential: Replace with a bitmap, that allows false-negative matches
 
         for coords in view_region.iter() {
             if coords.build_quad_key().is_none() {

--- a/maplibre/src/sdf/tessellation_new.rs
+++ b/maplibre/src/sdf/tessellation_new.rs
@@ -332,7 +332,7 @@ impl FeatureProcessor for TextTessellatorNew {
             | Some(Geometry::GeometryCollection(_))
             | Some(Geometry::Rect(_))
             | Some(Geometry::Triangle(_)) => {
-                log::debug!("Unsupported geometry in text tesselation")
+                log::debug!("Unsupported geometry in text tessellation")
             }
             None => {
                 log::debug!("No geometry in feature")

--- a/maplibre/src/vector/mod.rs
+++ b/maplibre/src/vector/mod.rs
@@ -41,7 +41,7 @@ mod resource_system;
 pub(crate) mod transferables;
 mod upload_system;
 
-// Public due to bechmarks
+// Public due to benchmarks
 pub mod tessellation;
 
 struct VectorPipeline(wgpu::RenderPipeline);

--- a/maplibre/src/vector/process_vector.rs
+++ b/maplibre/src/vector/process_vector.rs
@@ -218,9 +218,9 @@ pub fn process_vector_tile<T: VectorTransferables, C: Context>(
                         if let Err(e) = layer.process(&mut tessellator) {
                             context.layer_missing(coords, &source_layer)?;
 
-                            tracing::error!("tesselation for layer source {source_layer} at {coords} failed {e:?}");
+                            tracing::error!("tessellation for layer source {source_layer} at {coords} failed {e:?}");
                         } else {
-                            context.layer_tesselation_finished(
+                            context.layer_tessellation_finished(
                                 coords,
                                 tessellator.buffer.into(),
                                 tessellator.feature_indices,
@@ -241,10 +241,10 @@ pub fn process_vector_tile<T: VectorTransferables, C: Context>(
                         if let Err(e) = layer.process(&mut tessellator_new) {
                             context.layer_missing(coords, &source_layer)?;
 
-                            tracing::error!("tesselation for layer source {source_layer} at {coords} failed {e:?}");
+                            tracing::error!("tessellation for layer source {source_layer} at {coords} failed {e:?}");
                         } else {
                             tessellator_new.finish();
-                            context.symbol_layer_tesselation_finished(
+                            context.symbol_layer_tessellation_finished(
                                 coords,
                                 tessellator.quad_buffer.into(),
                                 tessellator_new.quad_buffer.into(),
@@ -336,7 +336,7 @@ impl<T: VectorTransferables, C: Context> ProcessVectorContext<T, C> {
             .map_err(|e| ProcessVectorError::SendError(e))
     }
 
-    fn layer_tesselation_finished(
+    fn layer_tessellation_finished(
         &mut self,
         coords: &WorldTileCoords,
         buffer: OverAlignedVertexBuffer<ShaderVertex, IndexDataType>,
@@ -357,7 +357,7 @@ impl<T: VectorTransferables, C: Context> ProcessVectorContext<T, C> {
             .map_err(|e| ProcessVectorError::SendError(e))
     }
 
-    fn symbol_layer_tesselation_finished(
+    fn symbol_layer_tessellation_finished(
         &mut self,
         coords: &WorldTileCoords,
         buffer: OverAlignedVertexBuffer<ShaderSymbolVertex, IndexDataType>,

--- a/maplibre/src/vector/request_system.rs
+++ b/maplibre/src/vector/request_system.rs
@@ -64,7 +64,7 @@ impl<E: Environment, T: VectorTransferables> System for RequestSystem<E, T> {
                         continue;
                     }
 
-                    // TODO: Make tesselation depend on style? So maybe we need to request even if it exists
+                    // TODO: Make tessellation depend on style? So maybe we need to request even if it exists
                     if world
                         .tiles
                         .query::<&VectorLayerBucketComponent>(coords)

--- a/maplibre/src/vector/resource/buffer_pool.rs
+++ b/maplibre/src/vector/resource/buffer_pool.rs
@@ -195,7 +195,7 @@ impl<Q: Queue<B>, B, V: Pod, I: Pod, TM: Pod, FM: Pod> BufferPool<Q, B, V, I, TM
         &self.feature_metadata.inner
     }
 
-    /// The VertexBuffers can contain padding elements. Not everything from a VertexBuffers is useable.
+    /// The VertexBuffers can contain padding elements. Not everything from a VertexBuffers is usable.
     /// The function returns the `bytes` and `aligned_bytes`. See [`OverAlignedVertexBuffer`].
     fn align(
         stride: wgpu::BufferAddress,

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@ let
     { };
 in
 (pkgs.mkShell.override {
-  # Wew are using the host clang on macOS; the Nix clang adds a clag that breaks cross compilation here:
+  # We are using the host clang on macOS; the Nix clang adds a clag that breaks cross compilation here:
   # https://github.com/NixOS/nixpkgs/blob/362cb82b75394680990cbe89f40fe65d35f66617/pkgs/build-support/cc-wrapper/default.nix#L490
   # It caused this error during the compilation of ring: clang-15: error: invalid argument '-mmacos-version-min=11.0' not allowed with '-miphoneos-version-min=7.0'
   stdenv = if stdenv.isDarwin then stdenvNoCC else llvmPackages_16.stdenv;

--- a/web/src/platform/singlethreaded/apc.rs
+++ b/web/src/platform/singlethreaded/apc.rs
@@ -250,7 +250,7 @@ impl<K: OffscreenKernel> AsyncProcedureCall<K> for PassingAsyncProcedureCall {
         input: Input,
         procedure: AsyncProcedure<K, UsedContext>,
     ) -> Result<(), CallError> {
-        let procedure_ptr = procedure as *mut AsyncProcedure<K, UsedContext>; // TODO: Verify how these poitner are converted to pointers
+        let procedure_ptr = procedure as *mut AsyncProcedure<K, UsedContext>; // TODO: Verify how these pointer are converted to pointers
         let input = serde_json::to_string(&input).map_err(|e| CallError::Serialize(Box::new(e)))?;
 
         let message = js_sys::Object::from_entries(&js_sys::Array::of3(


### PR DESCRIPTION
Fix a few typos identified with codespell.

Unsure if changes to `maplibre/src/legacy/*` is welcome; these can be rolled-back if to be kept truly legacy.