### PR TITLE
Add offline MBTiles source for Apple

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ android_logger = "0.14.1"
 png = { version = "0.17.10" }
 reqwest = { version = "0.12.5", default-features = false, features = ["rustls-tls", "gzip"] }  # Use rusttls on android because cross compiling is difficult
 rstar = "0.12.0"
-rusqlite = { version = "0.32.0" }
+rusqlite = { version = "0.32.0", features = ["bundled"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 smallvec = "1.11.1"

--- a/apple/Cargo.toml
+++ b/apple/Cargo.toml
@@ -15,7 +15,9 @@ authors.workspace = true
 maplibre = { path = "../maplibre", features = ["thread-safe-futures"] }
 maplibre-winit = { path = "../maplibre-winit", version = "0.1.0"  }
 
-env_logger.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [lib]
 name = "maplibre_apple"

--- a/apple/MapLibreRs/README.md
+++ b/apple/MapLibreRs/README.md
@@ -1,3 +1,39 @@
 # MapLibreRs
 
-A description of this package.
+This package supplies the MapLibre Rust renderer to an Apple host.
+
+## Local MBTiles source
+
+Put the MBTiles archive and the map style in the application bundle. Resolve
+their file URLs at run time. Then start the renderer with the archive and the
+style:
+
+```swift
+enum OfflineMapError: Error {
+    case missingResource(String)
+}
+
+func startOfflineMap() throws {
+    guard let archiveURL = Bundle.main.url(
+        forResource: "NavigationData",
+        withExtension: "mbtiles"
+    ) else {
+        throw OfflineMapError.missingResource("NavigationData.mbtiles")
+    }
+    guard let styleURL = Bundle.main.url(
+        forResource: "NavigationStyle",
+        withExtension: "json"
+    ) else {
+        throw OfflineMapError.missingResource("NavigationStyle.json")
+    }
+    let styleJSON = try String(contentsOf: styleURL, encoding: .utf8)
+    try MapLibre.start(mbtilesArchive: archiveURL, styleJSON: styleJSON)
+}
+```
+
+The local source opens the archive in read-only mode. It converts XYZ rows to
+TMS rows. It decompresses gzip tiles before the renderer reads them. It does not
+make a network request.
+
+The archive must have an MBTiles `metadata` table and a `tiles` table or view.
+The style must use source layer names that are in the vector tiles.

--- a/apple/src/lib.rs
+++ b/apple/src/lib.rs
@@ -1,14 +1,19 @@
+//! Apple host facade for the MapLibre Rust renderer.
+
 #![deny(unused_imports)]
 
-use maplibre::render::settings::WgpuSettings;
-use maplibre_winit::{run_headed_map, WinitMapWindowConfig};
+use std::{ffi::CStr, os::raw::c_char, path::PathBuf};
+
+use maplibre::{render::settings::WgpuSettings, style::Style};
+use maplibre_winit::{run_headed_map, run_headed_map_with_mbtiles, WinitMapWindowConfig};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[cfg(not(any(no_pendantic_os_check, target_os = "macos", target_os = "ios")))]
 compile_error!("apple works only on macOS and iOS.");
 
 #[no_mangle]
 pub fn maplibre_apple_main() {
-    env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
+    initialize_diagnostics();
 
     run_headed_map::<String>(
         None,
@@ -19,3 +24,75 @@ pub fn maplibre_apple_main() {
         },
     );
 }
+
+/// Starts the Apple renderer with one read-only MBTiles archive.
+///
+/// # Safety
+///
+/// `archive_path` and `style_json` must point to valid, null-terminated UTF-8 strings for the
+/// duration of this call.
+#[no_mangle]
+pub unsafe extern "C" fn maplibre_apple_main_with_mbtiles(
+    archive_path: *const c_char,
+    style_json: *const c_char,
+) -> bool {
+    initialize_diagnostics();
+    if archive_path.is_null() || style_json.is_null() {
+        tracing::error!("The MBTiles archive path or style JSON is null");
+        return false;
+    }
+    let archive_path = unsafe { CStr::from_ptr(archive_path) };
+    let style_json = unsafe { CStr::from_ptr(style_json) };
+    let Ok(archive_path) = archive_path.to_str() else {
+        tracing::error!("The MBTiles archive path is not valid UTF-8");
+        return false;
+    };
+    let Ok(style_json) = style_json.to_str() else {
+        tracing::error!("The style JSON is not valid UTF-8");
+        return false;
+    };
+    let Ok(mut style) = serde_json::from_str::<Style>(style_json) else {
+        tracing::error!("The style JSON is not valid");
+        return false;
+    };
+    if let Err(position) = assign_style_layer_indices(&mut style) {
+        tracing::error!(position, "The style has too many layers");
+        return false;
+    }
+
+    match run_headed_map_with_mbtiles(
+        PathBuf::from(archive_path),
+        style,
+        WinitMapWindowConfig::new("maplibre".to_string()),
+        WgpuSettings {
+            backends: Some(maplibre::render::settings::Backends::all()),
+            ..WgpuSettings::default()
+        },
+    ) {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::error!("Failed to start with the MBTiles archive: {error}");
+            false
+        }
+    }
+}
+
+fn assign_style_layer_indices(style: &mut Style) -> Result<(), usize> {
+    for (position, layer) in style.layers.iter_mut().enumerate() {
+        layer.index = u32::try_from(position).map_err(|_| position)?;
+    }
+    Ok(())
+}
+
+fn initialize_diagnostics() {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(filter)
+        .try_init()
+        .ok();
+}
+
+#[cfg(test)]
+mod tests;

--- a/apple/src/tests.rs
+++ b/apple/src/tests.rs
@@ -1,0 +1,60 @@
+use std::ffi::CString;
+
+use maplibre::style::Style;
+
+use super::{assign_style_layer_indices, maplibre_apple_main_with_mbtiles};
+
+#[test]
+fn local_source_entry_point_rejects_null_configuration() {
+    let accepted = unsafe { maplibre_apple_main_with_mbtiles(std::ptr::null(), std::ptr::null()) };
+
+    assert!(!accepted);
+}
+
+#[test]
+fn local_source_entry_point_rejects_invalid_style() {
+    let archive = CString::new("/not/opened.mbtiles").unwrap();
+    let style = CString::new("not-json").unwrap();
+
+    let accepted = unsafe { maplibre_apple_main_with_mbtiles(archive.as_ptr(), style.as_ptr()) };
+
+    assert!(!accepted);
+}
+
+#[test]
+fn local_source_entry_point_rejects_missing_archive() {
+    let archive = CString::new("/missing/maplibre-rs.mbtiles").unwrap();
+    let style = CString::new(r#"{"version":8,"layers":[]}"#).unwrap();
+
+    let accepted = unsafe { maplibre_apple_main_with_mbtiles(archive.as_ptr(), style.as_ptr()) };
+
+    assert!(!accepted);
+}
+
+#[test]
+fn json_style_layers_keep_their_paint_order() {
+    let mut style: Style = serde_json::from_str(
+        r##"{
+            "version": 8,
+            "layers": [
+                {
+                    "id": "background",
+                    "type": "background",
+                    "paint": {"background-color": "#081827"}
+                },
+                {
+                    "id": "airways",
+                    "type": "line",
+                    "source-layer": "airways",
+                    "paint": {"line-color": "#F5C542"}
+                }
+            ]
+        }"##,
+    )
+    .unwrap();
+
+    assign_style_layer_indices(&mut style).unwrap();
+
+    assert_eq!(style.layers[0].index, 0);
+    assert_eq!(style.layers[1].index, 1);
+}

--- a/apple/xcode/maplibre-rs/maplibre.swift
+++ b/apple/xcode/maplibre-rs/maplibre.swift
@@ -1,5 +1,26 @@
+import Foundation
+
 public class MapLibre {
     public static func start() {
         maplibre_apple_main();
     }
+
+    public static func start(mbtilesArchive archiveURL: URL, styleJSON: String) throws {
+        guard archiveURL.isFileURL else {
+            throw MapLibreStartError.archiveIsNotAFileURL(archiveURL)
+        }
+        let accepted = archiveURL.path.withCString { path in
+            styleJSON.withCString { style in
+                maplibre_apple_main_with_mbtiles(path, style)
+            }
+        }
+        guard accepted else {
+            throw MapLibreStartError.archiveWasRejected(archiveURL)
+        }
+    }
+}
+
+public enum MapLibreStartError: Error {
+    case archiveIsNotAFileURL(URL)
+    case archiveWasRejected(URL)
 }

--- a/apple/xcode/maplibre-rs/maplibre_rs.h
+++ b/apple/xcode/maplibre-rs/maplibre_rs.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#include <stdbool.h>
 
 //! Project version number for maplibre_rs.
 FOUNDATION_EXPORT double maplibre_rsVersionNumber;
@@ -9,3 +10,4 @@ FOUNDATION_EXPORT const unsigned char maplibre_rsVersionString[];
 // In this header, you should import all the public headers of your framework using statements like #import <maplibre_rs/PublicHeader.h>
 
 void maplibre_apple_main();
+bool maplibre_apple_main_with_mbtiles(const char *archive_path, const char *style_json);

--- a/maplibre-winit/src/lib.rs
+++ b/maplibre-winit/src/lib.rs
@@ -181,7 +181,7 @@ impl<ET: 'static + PartialEq + Debug> EventLoop<ET> for WinitEventLoop<ET> {
                         map.reset() // TODO: Instead of resetting the whole map (incl. the renderer) only reset the renderer
                     }
                     Event::Resumed => {
-                        // FIXME unimplemented!()
+                        map.window().request_redraw();
                     }
                     _ => {}
                 }

--- a/maplibre-winit/src/noweb.rs
+++ b/maplibre-winit/src/noweb.rs
@@ -6,14 +6,17 @@
 use std::{marker::PhantomData, path::PathBuf};
 
 use maplibre::{
-    environment::OffscreenKernelConfig,
+    environment::{OffscreenKernel, OffscreenKernelConfig},
     event_loop::EventLoop,
-    io::apc::SchedulerAsyncProcedureCall,
+    io::{apc::SchedulerAsyncProcedureCall, source_client::HttpClient},
     kernel::{Kernel, KernelBuilder},
     map::Map,
     platform::{
-        http_client::ReqwestHttpClient, run_multithreaded, scheduler::TokioScheduler,
-        ReqwestOffscreenKernelEnvironment,
+        http_client::ReqwestHttpClient,
+        mbtiles_client::{MbtilesClient, MbtilesError},
+        run_multithreaded,
+        scheduler::TokioScheduler,
+        MbtilesOffscreenKernelEnvironment, ReqwestOffscreenKernelEnvironment,
     },
     render::{builder::RendererBuilder, settings::WgpuSettings, RenderPlugin},
     style::Style,
@@ -111,21 +114,71 @@ pub fn run_headed_map<P>(
 ) where
     P: Into<PathBuf>,
 {
-    run_multithreaded(async {
-        type Environment<S, HC, APC> =
-            WinitEnvironment<S, HC, ReqwestOffscreenKernelEnvironment, APC, ()>;
+    let cache_path = cache_path.map(Into::into);
+    let client = ReqwestHttpClient::new(cache_path.clone());
+    run_headed_map_with_client::<_, ReqwestOffscreenKernelEnvironment>(
+        client,
+        OffscreenKernelConfig {
+            cache_directory: cache_path.map(|path| path.to_string_lossy().into_owned()),
+            local_source_path: None,
+        },
+        Style::default(),
+        window_config,
+        wgpu_settings,
+    );
+}
 
-        let cache_path = cache_path.map(|path| path.into());
-        let client = ReqwestHttpClient::new(cache_path.clone());
+/// Runs a headed map with one read-only MBTiles archive and the specified style.
+pub fn run_headed_map_with_mbtiles<P>(
+    archive_path: P,
+    style: Style,
+    window_config: WinitMapWindowConfig<()>,
+    wgpu_settings: WgpuSettings,
+) -> Result<(), MbtilesError>
+where
+    P: Into<PathBuf>,
+{
+    let archive_path = archive_path.into();
+    let client = MbtilesClient::open_blocking(&archive_path)?;
+    let source_path = archive_path
+        .to_str()
+        .ok_or_else(|| MbtilesError::NonUtf8Path {
+            path: archive_path.clone(),
+        })?
+        .to_string();
+    run_headed_map_with_client::<_, MbtilesOffscreenKernelEnvironment>(
+        client,
+        OffscreenKernelConfig {
+            cache_directory: None,
+            local_source_path: Some(source_path),
+        },
+        style,
+        window_config,
+        wgpu_settings,
+    );
+    Ok(())
+}
 
-        let kernel: Kernel<Environment<_, _, _>> = KernelBuilder::new()
+/// Runs a headed map with the specified source client and worker environment.
+pub fn run_headed_map_with_client<HC, K>(
+    client: HC,
+    offscreen_kernel_config: OffscreenKernelConfig,
+    style: Style,
+    window_config: WinitMapWindowConfig<()>,
+    wgpu_settings: WgpuSettings,
+) where
+    HC: HttpClient,
+    K: OffscreenKernel,
+{
+    run_multithreaded(async move {
+        type Environment<S, HC, K, APC> = WinitEnvironment<S, HC, K, APC, ()>;
+
+        let kernel: Kernel<Environment<_, _, K, _>> = KernelBuilder::new()
             .with_map_window_config(window_config)
             .with_http_client(client.clone())
             .with_apc(SchedulerAsyncProcedureCall::new(
                 TokioScheduler::new(),
-                OffscreenKernelConfig {
-                    cache_directory: cache_path.map(|path| path.to_str().unwrap().to_string()),
-                },
+                offscreen_kernel_config,
             ))
             .with_scheduler(TokioScheduler::new())
             .build();
@@ -133,7 +186,7 @@ pub fn run_headed_map<P>(
         let renderer_builder = RendererBuilder::new().with_wgpu_settings(wgpu_settings);
 
         let mut map = Map::new(
-            Style::default(),
+            style,
             kernel,
             renderer_builder,
             vec![

--- a/maplibre/Cargo.toml
+++ b/maplibre/Cargo.toml
@@ -32,6 +32,8 @@ env_logger.workspace = true
 reqwest.workspace = true
 http-cache-reqwest.workspace = true
 reqwest-middleware.workspace = true
+flate2.workspace = true
+rusqlite.workspace = true
 tracing-tracy = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/maplibre/src/environment.rs
+++ b/maplibre/src/environment.rs
@@ -31,7 +31,10 @@ pub trait Environment: 'static {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct OffscreenKernelConfig {
+    /// The optional HTTP response cache directory.
     pub cache_directory: Option<String>,
+    /// The optional path for a local source client.
+    pub local_source_path: Option<String>,
 }
 
 pub trait OffscreenKernel: Send + Sync + 'static {

--- a/maplibre/src/headless.rs
+++ b/maplibre/src/headless.rs
@@ -43,6 +43,7 @@ pub async fn create_headless_renderer(
             TokioScheduler::new(),
             OffscreenKernelConfig {
                 cache_directory: None,
+                local_source_path: None,
             },
         ))
         .with_scheduler(TokioScheduler::new())

--- a/maplibre/src/platform.rs
+++ b/maplibre/src/platform.rs
@@ -6,6 +6,8 @@ pub use noweb::run_multithreaded;
 #[cfg(feature = "trace")]
 pub use noweb::trace;
 #[cfg(not(target_arch = "wasm32"))]
+pub use noweb::MbtilesOffscreenKernelEnvironment;
+#[cfg(not(target_arch = "wasm32"))]
 pub use noweb::ReqwestOffscreenKernelEnvironment;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -15,6 +17,12 @@ mod noweb;
 pub mod http_client {
     #[cfg(not(target_arch = "wasm32"))]
     pub use super::noweb::http_client::*;
+}
+
+/// MBTiles client for non-web targets.
+pub mod mbtiles_client {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use super::noweb::mbtiles_client::*;
 }
 
 /// Scheduler for non-web targets.

--- a/maplibre/src/platform/noweb.rs
+++ b/maplibre/src/platform/noweb.rs
@@ -12,8 +12,11 @@ use crate::{
 };
 
 pub mod http_client;
+pub mod mbtiles_client;
 pub mod scheduler;
 pub mod trace;
+
+use mbtiles_client::MbtilesClient;
 
 pub fn run_multithreaded<F: Future>(future: F) -> F::Output {
     tokio::runtime::Builder::new_multi_thread()
@@ -48,5 +51,24 @@ impl OffscreenKernel for ReqwestOffscreenKernelEnvironment {
         SourceClient::new(HttpSourceClient::new(ReqwestHttpClient::new::<String>(
             self.0.cache_directory.clone(),
         )))
+    }
+}
+
+/// Creates worker-side source clients for one installed MBTiles archive.
+pub struct MbtilesOffscreenKernelEnvironment(MbtilesClient);
+
+impl OffscreenKernel for MbtilesOffscreenKernelEnvironment {
+    type HttpClient = MbtilesClient;
+
+    fn create(config: OffscreenKernelConfig) -> Self {
+        let client = match config.local_source_path {
+            Some(path) => MbtilesClient::configured(path),
+            None => MbtilesClient::unavailable("the local source path is not configured"),
+        };
+        Self(client)
+    }
+
+    fn source_client(&self) -> SourceClient<Self::HttpClient> {
+        SourceClient::new(HttpSourceClient::new(self.0.clone()))
     }
 }

--- a/maplibre/src/platform/noweb/mbtiles_client.rs
+++ b/maplibre/src/platform/noweb/mbtiles_client.rs
@@ -1,0 +1,252 @@
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use flate2::read::GzDecoder;
+use rusqlite::{Connection, OpenFlags, OptionalExtension};
+use thiserror::Error;
+
+use crate::io::source_client::{HttpClient, SourceFetchError};
+
+const MAX_ZOOM: u8 = 32;
+
+/// Reads one installed MBTiles archive without network access.
+///
+/// The client gets an XYZ coordinate from the final three parts of each requested tile URL. It
+/// converts the row to the TMS addressing scheme that MBTiles uses. It decompresses a gzip tile
+/// before it returns the tile to the renderer.
+#[derive(Clone, Debug)]
+pub struct MbtilesClient {
+    archive: Archive,
+}
+
+#[derive(Clone, Debug)]
+enum Archive {
+    Available(Arc<PathBuf>),
+    Unavailable(Arc<str>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TileCoordinate {
+    zoom: u8,
+    column: u32,
+    row: u32,
+}
+
+#[derive(Debug, Error)]
+/// A local MBTiles source error.
+pub enum MbtilesError {
+    #[error("the tile URL has no valid z/x/y coordinate: {url}")]
+    InvalidTileUrl { url: String },
+    #[error("tile coordinate {zoom}/{column}/{row} is outside its zoom matrix")]
+    CoordinateOutOfRange { zoom: u8, column: u32, row: u32 },
+    #[error("the MBTiles client is unavailable: {reason}")]
+    Unavailable { reason: Arc<str> },
+    #[error("failed to open MBTiles archive {path}")]
+    Open {
+        path: PathBuf,
+        #[source]
+        source: rusqlite::Error,
+    },
+    #[error("MBTiles archive {path} has no tiles table")]
+    MissingTilesTable { path: PathBuf },
+    #[error("MBTiles archive {path} has no metadata table")]
+    MissingMetadataTable { path: PathBuf },
+    #[error("the MBTiles archive path is not valid UTF-8: {path}")]
+    NonUtf8Path { path: PathBuf },
+    #[error("failed to read tile {zoom}/{column}/{row} from MBTiles archive {path}")]
+    Read {
+        path: PathBuf,
+        zoom: u8,
+        column: u32,
+        row: u32,
+        #[source]
+        source: rusqlite::Error,
+    },
+    #[error("MBTiles archive {path} has no tile {zoom}/{column}/{row}")]
+    MissingTile {
+        path: PathBuf,
+        zoom: u8,
+        column: u32,
+        row: u32,
+    },
+    #[error("failed to decompress tile {zoom}/{column}/{row} from MBTiles archive {path}")]
+    Decompress {
+        path: PathBuf,
+        zoom: u8,
+        column: u32,
+        row: u32,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("the MBTiles read task failed")]
+    Task {
+        #[source]
+        source: tokio::task::JoinError,
+    },
+}
+
+impl MbtilesClient {
+    /// Opens and validates an MBTiles archive.
+    ///
+    /// The reader opens the archive in read-only mode. This function blocks on file I/O.
+    pub fn open_blocking(path: impl Into<PathBuf>) -> Result<Self, MbtilesError> {
+        let path = path.into();
+        let connection = open_read_only(&path)?;
+        if !has_table_or_view(&connection, &path, "tiles")? {
+            return Err(MbtilesError::MissingTilesTable { path });
+        }
+        if !has_table_or_view(&connection, &path, "metadata")? {
+            return Err(MbtilesError::MissingMetadataTable { path });
+        }
+
+        Ok(Self::configured(path))
+    }
+
+    pub(crate) fn configured(path: impl Into<PathBuf>) -> Self {
+        Self {
+            archive: Archive::Available(Arc::new(path.into())),
+        }
+    }
+
+    pub(crate) fn unavailable(reason: impl Into<Arc<str>>) -> Self {
+        Self {
+            archive: Archive::Unavailable(reason.into()),
+        }
+    }
+
+    fn archive_path(&self) -> Result<Arc<PathBuf>, MbtilesError> {
+        match &self.archive {
+            Archive::Available(path) => Ok(path.clone()),
+            Archive::Unavailable(reason) => Err(MbtilesError::Unavailable {
+                reason: reason.clone(),
+            }),
+        }
+    }
+}
+
+#[cfg_attr(not(feature = "thread-safe-futures"), async_trait(?Send))]
+#[cfg_attr(feature = "thread-safe-futures", async_trait)]
+impl HttpClient for MbtilesClient {
+    async fn fetch(&self, url: &str) -> Result<Vec<u8>, SourceFetchError> {
+        let coordinate = parse_tile_coordinate(url).map_err(source_error)?;
+        let archive_path = self.archive_path().map_err(source_error)?;
+        tokio::task::spawn_blocking(move || read_tile_blocking(&archive_path, coordinate))
+            .await
+            .map_err(|source| source_error(MbtilesError::Task { source }))?
+            .map_err(source_error)
+    }
+}
+
+fn source_error(error: MbtilesError) -> SourceFetchError {
+    SourceFetchError(Box::new(error))
+}
+
+fn parse_tile_coordinate(url: &str) -> Result<TileCoordinate, MbtilesError> {
+    let path = url.split_once('?').map_or(url, |(path, _)| path);
+    let mut segments = path.rsplit('/');
+    let row = segments
+        .next()
+        .and_then(|value| value.split('.').next())
+        .and_then(|value| value.parse::<u32>().ok());
+    let column = segments.next().and_then(|value| value.parse::<u32>().ok());
+    let zoom = segments.next().and_then(|value| value.parse::<u8>().ok());
+    let (Some(zoom), Some(column), Some(row)) = (zoom, column, row) else {
+        return Err(MbtilesError::InvalidTileUrl {
+            url: url.to_string(),
+        });
+    };
+
+    if zoom > MAX_ZOOM {
+        return Err(MbtilesError::CoordinateOutOfRange { zoom, column, row });
+    }
+    let matrix_size = 1_u64 << zoom;
+    if u64::from(column) >= matrix_size || u64::from(row) >= matrix_size {
+        return Err(MbtilesError::CoordinateOutOfRange { zoom, column, row });
+    }
+
+    Ok(TileCoordinate { zoom, column, row })
+}
+
+fn read_tile_blocking(path: &Path, coordinate: TileCoordinate) -> Result<Vec<u8>, MbtilesError> {
+    let connection = open_read_only(path)?;
+    let matrix_size = 1_u64 << coordinate.zoom;
+    let tms_row = matrix_size - 1 - u64::from(coordinate.row);
+    let tile = connection
+        .query_row(
+            "SELECT tile_data FROM tiles \
+             WHERE zoom_level = ?1 AND tile_column = ?2 AND tile_row = ?3",
+            (
+                i64::from(coordinate.zoom),
+                i64::from(coordinate.column),
+                tms_row as i64,
+            ),
+            |row| row.get::<_, Vec<u8>>(0),
+        )
+        .optional()
+        .map_err(|source| MbtilesError::Read {
+            path: path.to_path_buf(),
+            zoom: coordinate.zoom,
+            column: coordinate.column,
+            row: coordinate.row,
+            source,
+        })?
+        .ok_or_else(|| MbtilesError::MissingTile {
+            path: path.to_path_buf(),
+            zoom: coordinate.zoom,
+            column: coordinate.column,
+            row: coordinate.row,
+        })?;
+
+    if tile.starts_with(&[0x1f, 0x8b]) {
+        let mut decoded = Vec::new();
+        GzDecoder::new(tile.as_slice())
+            .read_to_end(&mut decoded)
+            .map_err(|source| MbtilesError::Decompress {
+                path: path.to_path_buf(),
+                zoom: coordinate.zoom,
+                column: coordinate.column,
+                row: coordinate.row,
+                source,
+            })?;
+        Ok(decoded)
+    } else {
+        Ok(tile)
+    }
+}
+
+fn open_read_only(path: &Path) -> Result<Connection, MbtilesError> {
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|source| MbtilesError::Open {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn has_table_or_view(
+    connection: &Connection,
+    path: &Path,
+    name: &str,
+) -> Result<bool, MbtilesError> {
+    connection
+        .query_row(
+            "SELECT 1 FROM sqlite_schema WHERE type IN ('table', 'view') AND name = ?1",
+            [name],
+            |_| Ok(()),
+        )
+        .optional()
+        .map(|entry| entry.is_some())
+        .map_err(|source| MbtilesError::Open {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+#[cfg(test)]
+mod tests;

--- a/maplibre/src/platform/noweb/mbtiles_client/tests.rs
+++ b/maplibre/src/platform/noweb/mbtiles_client/tests.rs
@@ -1,0 +1,147 @@
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use flate2::{write::GzEncoder, Compression};
+use rusqlite::Connection;
+
+use super::{parse_tile_coordinate, HttpClient, MbtilesClient, MbtilesError, TileCoordinate};
+
+static NEXT_ARCHIVE: AtomicU64 = AtomicU64::new(0);
+
+struct TestArchive(PathBuf);
+
+impl TestArchive {
+    fn new(tile: &[u8]) -> Self {
+        let sequence = NEXT_ARCHIVE.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "maplibre-rs-mbtiles-{}-{sequence}.mbtiles",
+            std::process::id()
+        ));
+        create_archive(&path, tile);
+        Self(path)
+    }
+}
+
+impl Drop for TestArchive {
+    fn drop(&mut self) {
+        fs::remove_file(&self.0).ok();
+    }
+}
+
+#[tokio::test]
+async fn reads_gzipped_xyz_tile_from_tms_archive_without_network() {
+    let payload = b"mapbox-vector-tile";
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(payload).unwrap();
+    let archive = TestArchive::new(&encoder.finish().unwrap());
+    let bytes_before = fs::read(&archive.0).unwrap();
+    let client = MbtilesClient::open_blocking(&archive.0).unwrap();
+
+    let tile = client
+        .fetch("https://must-not-resolve.invalid/2/1/2.pbf")
+        .await
+        .unwrap();
+
+    assert_eq!(tile, payload);
+    assert_eq!(fs::read(&archive.0).unwrap(), bytes_before);
+}
+
+#[tokio::test]
+async fn returns_uncompressed_tile_unchanged() {
+    let payload = b"png-data";
+    let archive = TestArchive::new(payload);
+    let client = MbtilesClient::open_blocking(&archive.0).unwrap();
+
+    let tile = client.fetch("tiles/2/1/2.png?ignored=true").await.unwrap();
+
+    assert_eq!(tile, payload);
+}
+
+#[test]
+fn rejects_coordinates_outside_zoom_matrix() {
+    let error = parse_tile_coordinate("tiles/2/4/0.pbf").unwrap_err();
+
+    assert!(matches!(error, MbtilesError::CoordinateOutOfRange { .. }));
+}
+
+#[test]
+fn rejects_zoom_above_u32_coordinate_range() {
+    let error = parse_tile_coordinate("tiles/33/1/1.pbf").unwrap_err();
+
+    assert!(matches!(error, MbtilesError::CoordinateOutOfRange { .. }));
+}
+
+#[test]
+fn rejects_archive_without_tiles_table() {
+    let archive = TestArchive::new(b"tile");
+    fs::remove_file(&archive.0).unwrap();
+    let connection = Connection::open(&archive.0).unwrap();
+    connection
+        .execute("CREATE TABLE metadata (name TEXT, value TEXT)", [])
+        .unwrap();
+
+    let error = MbtilesClient::open_blocking(&archive.0).unwrap_err();
+
+    assert!(matches!(error, MbtilesError::MissingTilesTable { .. }));
+}
+
+#[test]
+fn rejects_archive_without_metadata_table() {
+    let archive = TestArchive::new(b"tile");
+    let connection = Connection::open(&archive.0).unwrap();
+    connection.execute("DROP TABLE metadata", []).unwrap();
+
+    let error = MbtilesClient::open_blocking(&archive.0).unwrap_err();
+
+    assert!(matches!(error, MbtilesError::MissingMetadataTable { .. }));
+}
+
+#[test]
+fn accepts_normalized_tiles_view() {
+    let archive = TestArchive::new(b"tile");
+    let connection = Connection::open(&archive.0).unwrap();
+    connection
+        .execute("ALTER TABLE tiles RENAME TO tile_rows", [])
+        .unwrap();
+    connection
+        .execute("CREATE VIEW tiles AS SELECT * FROM tile_rows", [])
+        .unwrap();
+
+    MbtilesClient::open_blocking(&archive.0).unwrap();
+}
+
+#[test]
+fn parses_xyz_coordinate_with_extension_and_query() {
+    let coordinate = parse_tile_coordinate("mbtiles://source/8/72/93.pbf?key=no-network").unwrap();
+
+    assert_eq!(
+        coordinate,
+        TileCoordinate {
+            zoom: 8,
+            column: 72,
+            row: 93,
+        }
+    );
+}
+
+fn create_archive(path: &Path, tile: &[u8]) {
+    let connection = Connection::open(path).unwrap();
+    connection
+        .execute_batch(
+            "CREATE TABLE metadata (name TEXT, value TEXT); \
+             CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, \
+             tile_row INTEGER, tile_data BLOB);",
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO tiles (zoom_level, tile_column, tile_row, tile_data) \
+             VALUES (2, 1, 1, ?1)",
+            [tile],
+        )
+        .unwrap();
+}

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -92,6 +92,7 @@ pub async fn run_maplibre(new_worker: js_sys::Function) -> Result<(), JSError> {
 
     let offscreen_kernel_config = OffscreenKernelConfig {
         cache_directory: None,
+        local_source_path: None,
     };
 
     #[cfg(target_feature = "atomics")]


### PR DESCRIPTION
## Summary

- add a read-only MBTiles source client for native targets
- inject the same local source into main and worker kernels
- expose the source through the Apple C facade and Swift wrapper
- keep SQLite inside the static Apple framework
- preserve JSON style layer order

The client converts XYZ rows to TMS rows and decompresses gzip tile payloads. This path does not create an HTTP client.

This change implements the local file part of #76.

## Validation

- just fmt-check
- cargo test -p maplibre --lib: 39 passed, 2 ignored
- cargo test -p apple --lib: 4 passed
- cargo clippy --no-deps -p apple --target aarch64-apple-ios
- cargo clippy --no-deps -p maplibre-winit
- unsigned Xcode iOS example build with the iOS 27 SDK
- macOS probe read a reviewed MBTiles archive and emitted vector draw commands

## iOS runtime limit

The current winit Apple path uses the legacy application lifecycle. The iOS 27 runtime stops that path before renderer startup. This PR does not change the application lifecycle. The local source adapter and Apple build are independent of that upstream lifecycle work.